### PR TITLE
Feature/default logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ log = "0.4"
 lazy_static = "1.4"
 colored = "2"
 chrono = "0.4"
-
+simple_logger = "1.13"
 
 [dev-dependencies]
 test-case = "1.2"
-simple_logger = "1.13"

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -2,7 +2,6 @@ use log::info;
 use wolf_engine::logging;
 
 pub fn main() {
-    // Wolf Engine provides terminal logging through the SimpleLogger crate.
     logging::initialize_logging();
     info!("Hello, world!");
 }

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,0 +1,8 @@
+use log::info;
+use wolf_engine::logging;
+
+pub fn main() {
+    // Wolf Engine provides terminal logging through the SimpleLogger crate.
+    logging::initialize_logging();
+    info!("Hello, world!");
+}

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,7 +1,10 @@
-use log::info;
+use log::{LevelFilter, debug, error, info, warn};
 use wolf_engine::logging;
 
 pub fn main() {
-    logging::initialize_logging();
+    logging::initialize_logging(LevelFilter::Debug);
     info!("Hello, world!");
+    debug!("This is some debug information.");
+    warn!("Here is a warning!");
+    error!("Something has gone wrong!")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ mod engine;
 
 pub mod context;
 pub mod game_loop;
+pub mod logging;
 
 pub use context::{Context, ContextBuilder};
 pub use engine::*;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -12,7 +12,7 @@ use simple_logger::SimpleLogger;
 /// 
 /// ```
 /// # use wolf_engine::logging;
-/// # use simple_logger::LevelFilter;
+/// # use log::LevelFilter;
 /// #
 /// logging::initialize_logging(LevelFilter::Debug);
 /// ```
@@ -21,7 +21,7 @@ use simple_logger::SimpleLogger;
 /// 
 /// ```
 /// # use wolf_engine::logging;
-/// # use simple_logger::{LevelFilter, info};
+/// # use log::{LevelFilter, info};
 /// # logging::initialize_logging(LevelFilter::Debug);
 /// #
 /// info!("Hello, world!");

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,1 @@
+pub fn initialize_logging() {}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,3 +1,5 @@
+//! Provides a default logging implementation using the [simple_logger] crate.
+
 use log::LevelFilter;
 use simple_logger::SimpleLogger;
 
@@ -26,7 +28,6 @@ use simple_logger::SimpleLogger;
 /// #
 /// info!("Hello, world!");
 /// ```
-/// 
 pub fn initialize_logging(log_level: LevelFilter) {
     SimpleLogger::new()
         .with_colors(true)

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,1 +1,3 @@
-pub fn initialize_logging() {}
+use log::LevelFilter;
+
+pub fn initialize_logging(log_level: LevelFilter) {}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,12 +5,13 @@ use simple_logger::SimpleLogger;
 
 /// Initialize the default logger.
 /// 
-/// This function is provided for those who don't need a complicated logging setup.  The default
-/// logger will output messages to the terminal.
+/// This function is provided for those who don't need a complicated logging setup.  Messages
+/// will be logged to the terminal.
 /// 
 /// # Examples
 /// 
-/// To use the default logger, just initialize it by calling this function.
+/// To use the default logger, just initialize it by calling this function and providing it with
+/// the desired [LevelFilter].
 /// 
 /// ```
 /// # use wolf_engine::logging;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -22,9 +22,7 @@ use simple_logger::SimpleLogger;
 /// Messages are logged using [log] macros. 
 /// 
 /// ```
-/// # use wolf_engine::logging;
-/// # use log::{LevelFilter, info};
-/// # logging::initialize_logging(LevelFilter::Debug);
+/// # use log::info;
 /// #
 /// info!("Hello, world!");
 /// ```

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,3 +1,10 @@
 use log::LevelFilter;
+use simple_logger::SimpleLogger;
 
-pub fn initialize_logging(log_level: LevelFilter) {}
+pub fn initialize_logging(log_level: LevelFilter) {
+    SimpleLogger::new()
+        .with_colors(true)
+        .with_level(log_level)
+        .init()
+        .expect("Failed to initialize the logger");
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,6 +1,32 @@
 use log::LevelFilter;
 use simple_logger::SimpleLogger;
 
+/// Initialize the default logger.
+/// 
+/// This function is provided for those who don't need a complicated logging setup.  The default
+/// logger will output messages to the terminal.
+/// 
+/// # Examples
+/// 
+/// To use the default logger, just initialize it by calling this function.
+/// 
+/// ```
+/// # use wolf_engine::logging;
+/// # use simple_logger::LevelFilter;
+/// #
+/// logging::initialize_logging(LevelFilter::Debug);
+/// ```
+/// 
+/// Messages are logged using [log] macros. 
+/// 
+/// ```
+/// # use wolf_engine::logging;
+/// # use simple_logger::{LevelFilter, info};
+/// # logging::initialize_logging(LevelFilter::Debug);
+/// #
+/// info!("Hello, world!");
+/// ```
+/// 
 pub fn initialize_logging(log_level: LevelFilter) {
     SimpleLogger::new()
         .with_colors(true)


### PR DESCRIPTION
Providing a helper function to initialize a default terminal logger, using [Simple Logger](https://lib.rs/crates/simple_logger), is a good idea for those who want it. If more is needed of the logging framework, projects should use whichever logging framework best suits the project.

# Changes

- [x] Added a function to setup the default logger.
- [x] Added an example of using the default logger.
- [x] Added terminal logging using the `simple_logger` crate.

# Checklist

- [x] Update the documentation.
- [x] Clean up and refactor new code.
- [x] Resolve all Clippy warnings.