### PR TITLE
Refactor/better engine initalization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wolf_engine"
 description = "A game framework with a focus on flexibility and ease of use."
-version = "0.5.0"
+version = "0.6.0"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/multiple_states.rs
+++ b/examples/multiple_states.rs
@@ -8,13 +8,6 @@ use wolf_engine::{
 
 pub fn main() {
     initialize_logging(LevelFilter::Debug);
-
-    let starting_state = MainState::new();
-
-    let context = ContextBuilder::new().build();
-    EngineBuilder::with_default_scheduler()
-        .build(context)
-        .run(Box::from(starting_state));
 }
 
 pub struct MainState {

--- a/examples/multiple_states.rs
+++ b/examples/multiple_states.rs
@@ -2,12 +2,14 @@ use std::{thread, time::Duration};
 
 use log::{debug, info, LevelFilter};
 use wolf_engine::{
-    initialize_logging, Context, ContextBuilder, EngineBuilder, OptionalTransition, RenderResult,
-    State, Transition,
+    initialize_logging, Context, Engine, OptionalTransition, RenderResult, State, Transition,
 };
 
 pub fn main() {
     initialize_logging(LevelFilter::Debug);
+    let state = MainState::new();
+
+    Engine::new().run(Box::from(state));
 }
 
 pub struct MainState {

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -5,8 +5,20 @@ pub fn main() {
     // Wolf Engine includes a default logger for convenience, but using it is optional.
     // Feel free to bring your own logger.
     initialize_logging(LevelFilter::Debug);
+    
+    // Initialize your game state. 
+    let game = FizzBuzzState::new();
+    
+    // Pass your state to the engine.  Have fun!
+    Engine::new()
+        .run(Box::from(game));
 }
 
+
+// Your game is implemented as one or many game states.  A game state stores all the 
+// data and logic for your game.  You pass an instance of the game state to the engine, 
+// and the engine will run the game state.  Game states can interact with the engine
+// through the Context object, and by returning Transitions.
 pub struct FizzBuzzState {
     number: u64,
 }

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -5,22 +5,6 @@ pub fn main() {
     // Wolf Engine includes a default logger for convenience, but using it is optional.
     // Feel free to bring your own logger.
     initialize_logging(LevelFilter::Debug);
-
-    // Start by initializing the Context object.
-    let context = ContextBuilder::new()
-        // Custom settings go here.
-        .build();
-
-    // Then build an instance of the engine.
-    let engine = EngineBuilder::with_default_scheduler()
-        // Custom settings go here.
-        .build(context);
-
-    // Initialize your game state.
-    let game = FizzBuzzState::new();
-
-    // Then pass your game state to the engine on startup.  Have fun!
-    engine.run(Box::from(game));
 }
 
 pub struct FizzBuzzState {

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -5,18 +5,16 @@ pub fn main() {
     // Wolf Engine includes a default logger for convenience, but using it is optional.
     // Feel free to bring your own logger.
     initialize_logging(LevelFilter::Debug);
-    
-    // Initialize your game state. 
+
+    // Initialize your game state.
     let game = FizzBuzzState::new();
-    
+
     // Pass your state to the engine.  Have fun!
-    Engine::new()
-        .run(Box::from(game));
+    Engine::new().run(Box::from(game));
 }
 
-
-// Your game is implemented as one or many game states.  A game state stores all the 
-// data and logic for your game.  You pass an instance of the game state to the engine, 
+// Your game is implemented as one or many game states.  A game state stores all the
+// data and logic for your game.  You pass an instance of the game state to the engine,
 // and the engine will run the game state.  Game states can interact with the engine
 // through the Context object, and by returning Transitions.
 pub struct FizzBuzzState {

--- a/examples/state_basics.rs
+++ b/examples/state_basics.rs
@@ -2,12 +2,16 @@ use std::{thread, time::Duration};
 
 use log::{debug, info};
 use wolf_engine::{
-    initialize_logging, Context, ContextBuilder, EngineBuilder, OptionalTransition, RenderResult,
-    State, Transition,
+    initialize_logging, Context, OptionalTransition, RenderResult, State, Transition, Engine,
 };
 
 pub fn main() {
     initialize_logging(log::LevelFilter::Debug);
+
+    let state = MyState::new("Hello, world!");
+    
+    Engine::new()
+        .run(Box::from(state));    
 }
 
 pub struct MyState {

--- a/examples/state_basics.rs
+++ b/examples/state_basics.rs
@@ -2,16 +2,15 @@ use std::{thread, time::Duration};
 
 use log::{debug, info};
 use wolf_engine::{
-    initialize_logging, Context, OptionalTransition, RenderResult, State, Transition, Engine,
+    initialize_logging, Context, Engine, OptionalTransition, RenderResult, State, Transition,
 };
 
 pub fn main() {
     initialize_logging(log::LevelFilter::Debug);
 
     let state = MyState::new("Hello, world!");
-    
-    Engine::new()
-        .run(Box::from(state));    
+
+    Engine::new().run(Box::from(state));
 }
 
 pub struct MyState {

--- a/examples/state_basics.rs
+++ b/examples/state_basics.rs
@@ -8,13 +8,6 @@ use wolf_engine::{
 
 pub fn main() {
     initialize_logging(log::LevelFilter::Debug);
-
-    let my_state = MyState::new("Hello, World!");
-
-    let context = ContextBuilder::new().build();
-    EngineBuilder::with_default_scheduler()
-        .build(context)
-        .run(Box::from(my_state));
 }
 
 pub struct MyState {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -38,8 +38,7 @@ pub struct ContextBuilder {
 
 impl Default for Context {
     fn default() -> Self {
-        ContextBuilder::new()
-            .build()
+        ContextBuilder::new().build()
     }
 }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -36,6 +36,13 @@ pub struct ContextBuilder {
     event_loop: Option<EventLoop<()>>,
 }
 
+impl Default for Context {
+    fn default() -> Self {
+        ContextBuilder::new()
+            .build()
+    }
+}
+
 impl ContextBuilder {
     /// Create the default [ContextBuilder].
     pub fn new() -> Self {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -15,6 +15,17 @@ use crate::{
 /// The main job of the engine is to run the main loop. The engine takes an initial
 /// [State] object and pushes that onto it's internal [StateStack].  It will then run your
 /// game through the [StateStack] utilizing a [Scheduler] for timing control.
+///
+///
+/// For the default instance, just use:
+///
+/// ```
+/// # use wolf_engine::{Engine, EmptyState};
+/// # let my_game_state = EmptyState;
+///
+/// Engine::new()
+///     .run(Box::from(my_game_state));
+/// ```
 pub struct Engine<Schedule: Scheduler> {
     context: Context,
     scheduler: Schedule,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -93,7 +93,9 @@ impl Engine {
 
 impl Default for Engine {
     fn default() -> Self {
-        todo!();
+        let context = Context::default();
+        EngineBuilder::new()
+            .build(context)
     }
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -106,32 +106,6 @@ pub struct EngineBuilder<Loop: Scheduler> {
     scheduler: Loop,
 }
 
-impl EngineBuilder<FixedUpdateScheduler> {
-    pub fn with_default_scheduler() -> Self {
-        Self {
-            scheduler: Default::default(),
-        }
-    }
-
-    pub fn with_fixed_scheduler(scheduler: FixedUpdateScheduler) -> Self {
-        Self { scheduler }
-    }
-}
-
-impl<Loop: Scheduler> EngineBuilder<Loop> {
-    pub fn with_custom_scheduler(scheduler: Loop) -> Self {
-        Self { scheduler }
-    }
-
-    pub fn build(self, context: Context) -> Engine<Loop> {
-        Engine {
-            context,
-            scheduler: self.scheduler,
-            state_stack: StateStack::new(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod wolf_engine_tests {
     use crate::{ContextBuilder, MockState, Transition};

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -49,7 +49,7 @@ impl Engine<FixedUpdateScheduler> {
     }
 }
 
-impl<Loop: Scheduler> Engine<Loop> {
+impl<Schedule: Scheduler> Engine<Schedule> {
     pub fn run(mut self, initial_state: Box<dyn State>) {
         self.state_stack.push(initial_state);
         while !self.state_stack.is_empty() {
@@ -62,7 +62,7 @@ impl<Loop: Scheduler> Engine<Loop> {
 }
 
 #[cfg(feature = "window")]
-impl<Loop: Scheduler> Engine<Loop> {
+impl<Schedule: Scheduler> Engine<Schedule> {
     pub fn run_with_event_loop(mut self, initial_state: Box<dyn State>, event_loop: EventLoop<()>) {
         self.state_stack.push(initial_state);
         self.run_event_loop(event_loop);
@@ -102,8 +102,8 @@ impl Default for Engine<FixedUpdateScheduler> {
 
 
 /// Build and customize an instance of the [Engine].
-pub struct EngineBuilder<Loop: Scheduler> {
-    scheduler: Loop,
+pub struct EngineBuilder<Schedule: Scheduler> {
+    scheduler: Schedule,
 }
 
 #[cfg(test)]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -26,6 +26,16 @@ use crate::{
 /// Engine::new()
 ///     .run(Box::from(my_game_state));
 /// ```
+///
+/// Using Engine::default() does the same thing:
+///
+/// ```
+/// # use wolf_engine::{Engine, EmptyState};
+/// # let my_game_state = EmptyState;
+/// #
+/// Engine::default()
+///     .run(Box::from(my_game_state));
+/// ```
 pub struct Engine<Schedule: Scheduler> {
     context: Context,
     scheduler: Schedule,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -44,7 +44,7 @@ pub struct Engine {
 
 impl Engine {
     pub fn new() -> Self {
-        todo!()
+        Self::default() 
     }
 
     pub fn run(mut self, initial_state: Box<dyn State>) {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -102,8 +102,20 @@ impl Default for Engine<FixedUpdateScheduler> {
 
 
 /// Build and customize an instance of the [Engine].
-pub struct EngineBuilder<Schedule: Scheduler> {
-    scheduler: Schedule,
+pub struct EngineBuilder {
+    scheduler: Box<dyn Scheduler> 
+}
+
+impl EngineBuilder {
+   pub fn new() -> Self {
+       Self::default()
+   }
+}
+
+impl Default for EngineBuilder {
+    fn default() -> Self {
+        Self { scheduler: Box::from(FixedUpdateScheduler::default()) }
+    }
 }
 
 #[cfg(test)]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -9,7 +9,7 @@ use crate::{
 /// [State] object and pushes that onto it's internal [StateStack].  It will then run your
 /// game through the [StateStack] utilizing a [Scheduler] for timing control.
 ///
-/// If you just want to use the defaults, you can use `Engine::new()`.  Of course, you'll
+/// If you just want to use the defaults, you can use [Engine::new()].  Of course, you'll
 /// need to pass it your game's [State]:
 ///
 /// ```
@@ -20,7 +20,7 @@ use crate::{
 ///     .run(Box::from(my_game_state));
 /// ```
 ///
-/// Using Engine::default() does the same thing:
+/// Using [Engine::default()] does the same thing:
 ///
 /// ```
 /// # use wolf_engine::{Engine, EmptyState};

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -36,20 +36,17 @@ use crate::{
 /// Engine::default()
 ///     .run(Box::from(my_game_state));
 /// ```
-pub struct Engine<Schedule: Scheduler> {
+pub struct Engine {
     context: Context,
-    scheduler: Schedule,
+    scheduler: Box<dyn Scheduler>,
     state_stack: StateStack,
 }
 
-
-impl Engine<FixedUpdateScheduler> {
+impl Engine {
     pub fn new() -> Self {
         todo!()
     }
-}
 
-impl<Schedule: Scheduler> Engine<Schedule> {
     pub fn run(mut self, initial_state: Box<dyn State>) {
         self.state_stack.push(initial_state);
         while !self.state_stack.is_empty() {
@@ -62,7 +59,7 @@ impl<Schedule: Scheduler> Engine<Schedule> {
 }
 
 #[cfg(feature = "window")]
-impl<Schedule: Scheduler> Engine<Schedule> {
+impl Engine {
     pub fn run_with_event_loop(mut self, initial_state: Box<dyn State>, event_loop: EventLoop<()>) {
         self.state_stack.push(initial_state);
         self.run_event_loop(event_loop);
@@ -94,7 +91,7 @@ impl<Schedule: Scheduler> Engine<Schedule> {
     }
 }
 
-impl Default for Engine<FixedUpdateScheduler> {
+impl Default for Engine {
     fn default() -> Self {
         todo!();
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -117,7 +117,8 @@ impl EngineBuilder {
         } 
     }
 
-    pub fn with_scheduler(self, _scheduler: Box<dyn Scheduler>) -> Self {
+    pub fn with_scheduler(mut self, scheduler: Box<dyn Scheduler>) -> Self {
+        self.scheduler = scheduler;
         self 
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,8 +6,8 @@ use winit::{
 };
 
 use crate::{
-    scheduler::{FixedUpdateScheduler, Scheduler},
-    Context, State, StateStack,
+    scheduler::{FixedUpdateScheduler, Scheduler, FixedUpdateSchedulerBuilder},
+    Context, State, StateStack, ContextBuilder,
 };
 
 /// Provides the core functionality of the engine.
@@ -30,6 +30,13 @@ pub struct Engine<Schedule: Scheduler> {
     context: Context,
     scheduler: Schedule,
     state_stack: StateStack,
+}
+
+
+impl Engine<FixedUpdateScheduler> {
+    pub fn new() -> Self {
+        todo!()
+    }
 }
 
 impl<Loop: Scheduler> Engine<Loop> {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -147,3 +147,23 @@ mod wolf_engine_tests {
         wolf_engine.run(Box::from(state));
     }
 }
+
+
+#[cfg(test)]
+mod engine_builder_tests {
+    use super::*;
+    use crate::{scheduler::MockScheduler, EmptyState};
+
+    #[test]
+    fn should_allow_custom_states() {
+        let context = Context::default();
+        let mut scheduler = MockScheduler::new();
+        scheduler.expect_update()
+            .times(1);
+
+        EngineBuilder::new()
+            .with_scheduler(Box::from(scheduler))
+            .build(context)
+            .run(Box::from(EmptyState));
+    }
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -159,8 +159,8 @@ mod engine_builder_tests {
     fn should_allow_custom_states() {
         let context = Context::default();
         let mut scheduler = MockScheduler::new();
-        scheduler.expect_update()
-            .times(1);
+        scheduler.expect_update().times(1..).return_const(());           
+        scheduler.expect_render().times(..).return_const(());
 
         EngineBuilder::new()
             .with_scheduler(Box::from(scheduler))

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -109,8 +109,12 @@ impl EngineBuilder {
         Self::default()
     }
 
-    pub fn build(self, _context: Context) -> Engine {
-        todo!()
+    pub fn build(self, context: Context) -> Engine {
+        Engine { 
+            context, 
+            scheduler: self.scheduler, 
+            state_stack: StateStack::new()
+        } 
     }
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,10 +1,3 @@
-#[cfg(feature = "window")]
-use winit::{
-    event::*,
-    event_loop::{ControlFlow, EventLoop},
-    platform::run_return::EventLoopExtRunReturn,
-};
-
 use crate::{
     scheduler::{FixedUpdateScheduler, Scheduler},
     Context, State, StateStack,
@@ -55,39 +48,6 @@ impl Engine {
             self.scheduler
                 .render(&mut self.context, &mut self.state_stack);
         }
-    }
-}
-
-#[cfg(feature = "window")]
-impl Engine {
-    pub fn run_with_event_loop(mut self, initial_state: Box<dyn State>, event_loop: EventLoop<()>) {
-        self.state_stack.push(initial_state);
-        self.run_event_loop(event_loop);
-    }
-
-    fn run_event_loop(&mut self, mut event_loop: EventLoop<()>) {
-        event_loop.run_return(|event, _window, control_flow| {
-            match event {
-                Event::MainEventsCleared => {
-                    self.scheduler
-                        .update(&mut self.context, &mut self.state_stack);
-                }
-                Event::RedrawRequested(_) => {
-                    self.scheduler
-                        .render(&mut self.context, &mut self.state_stack);
-                }
-                Event::WindowEvent {
-                    event: WindowEvent::CloseRequested,
-                    ..
-                } => {
-                    self.state_stack.clear();
-                }
-                _ => (),
-            }
-            if self.state_stack.is_empty() {
-                *control_flow = ControlFlow::Exit;
-            }
-        });
     }
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -108,14 +108,13 @@ pub struct EngineBuilder<Schedule: Scheduler> {
 
 #[cfg(test)]
 mod wolf_engine_tests {
-    use crate::{ContextBuilder, MockState, Transition};
+    use crate::{MockState, Transition};
 
     use super::*;
 
     #[test]
     fn should_run_the_state() {
-        let context = ContextBuilder::new().build();
-        let wolf_engine = EngineBuilder::with_default_scheduler().build(context);
+        let wolf_engine = Engine::default();
         let mut state = MockState::new();
         state
             .expect_update()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -16,8 +16,8 @@ use crate::{
 /// [State] object and pushes that onto it's internal [StateStack].  It will then run your
 /// game through the [StateStack] utilizing a [Scheduler] for timing control.
 ///
-///
-/// For the default instance, just use:
+/// If you just want to use the defaults, you can use `Engine::new()`.  Of course, you'll
+/// need to pass it your game's [State]:
 ///
 /// ```
 /// # use wolf_engine::{Engine, EmptyState};

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,8 +6,8 @@ use winit::{
 };
 
 use crate::{
-    scheduler::{FixedUpdateScheduler, Scheduler, FixedUpdateSchedulerBuilder},
-    Context, State, StateStack, ContextBuilder,
+    scheduler::{FixedUpdateScheduler, Scheduler},
+    Context, State, StateStack,
 };
 
 /// Provides the core functionality of the engine.
@@ -96,7 +96,6 @@ impl Default for Engine {
         todo!();
     }
 }
-
 
 /// Build and customize an instance of the [Engine].
 pub struct EngineBuilder {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -94,6 +94,13 @@ impl<Loop: Scheduler> Engine<Loop> {
     }
 }
 
+impl Default for Engine<FixedUpdateScheduler> {
+    fn default() -> Self {
+        todo!();
+    }
+}
+
+
 /// Build and customize an instance of the [Engine].
 pub struct EngineBuilder<Loop: Scheduler> {
     scheduler: Loop,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -44,7 +44,7 @@ pub struct Engine {
 
 impl Engine {
     pub fn new() -> Self {
-        Self::default() 
+        Self::default()
     }
 
     pub fn run(mut self, initial_state: Box<dyn State>) {
@@ -94,14 +94,13 @@ impl Engine {
 impl Default for Engine {
     fn default() -> Self {
         let context = Context::default();
-        EngineBuilder::new()
-            .build(context)
+        EngineBuilder::new().build(context)
     }
 }
 
 /// Build and customize an instance of the [Engine].
 pub struct EngineBuilder {
-    scheduler: Box<dyn Scheduler> 
+    scheduler: Box<dyn Scheduler>,
 }
 
 impl EngineBuilder {
@@ -110,22 +109,24 @@ impl EngineBuilder {
     }
 
     pub fn build(self, context: Context) -> Engine {
-        Engine { 
-            context, 
-            scheduler: self.scheduler, 
-            state_stack: StateStack::new()
-        } 
+        Engine {
+            context,
+            scheduler: self.scheduler,
+            state_stack: StateStack::new(),
+        }
     }
 
     pub fn with_scheduler(mut self, scheduler: Box<dyn Scheduler>) -> Self {
         self.scheduler = scheduler;
-        self 
+        self
     }
 }
 
 impl Default for EngineBuilder {
     fn default() -> Self {
-        Self { scheduler: Box::from(FixedUpdateScheduler::default()) }
+        Self {
+            scheduler: Box::from(FixedUpdateScheduler::default()),
+        }
     }
 }
 
@@ -149,7 +150,6 @@ mod wolf_engine_tests {
     }
 }
 
-
 #[cfg(test)]
 mod engine_builder_tests {
     use super::*;
@@ -159,9 +159,12 @@ mod engine_builder_tests {
     fn should_allow_custom_states() {
         let context = Context::default();
         let mut scheduler = MockScheduler::new();
-        scheduler.expect_update()
+        scheduler
+            .expect_update()
             .times(1)
-            .returning(|context, state_stack| { state_stack.update(context); });
+            .returning(|context, state_stack| {
+                state_stack.update(context);
+            });
         scheduler.expect_render().times(..).return_const(());
 
         EngineBuilder::new()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -159,7 +159,9 @@ mod engine_builder_tests {
     fn should_allow_custom_states() {
         let context = Context::default();
         let mut scheduler = MockScheduler::new();
-        scheduler.expect_update().times(1..).return_const(());           
+        scheduler.expect_update()
+            .times(1)
+            .returning(|context, state_stack| { state_stack.update(context); });
         scheduler.expect_render().times(..).return_const(());
 
         EngineBuilder::new()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -116,6 +116,10 @@ impl EngineBuilder {
             state_stack: StateStack::new()
         } 
     }
+
+    pub fn with_scheduler(self, _scheduler: Box<dyn Scheduler>) -> Self {
+        self 
+    }
 }
 
 impl Default for EngineBuilder {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -105,9 +105,13 @@ pub struct EngineBuilder {
 }
 
 impl EngineBuilder {
-   pub fn new() -> Self {
-       Self::default()
-   }
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn build(self, _context: Context) -> Engine {
+        todo!()
+    }
 }
 
 impl Default for EngineBuilder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!```
 //!
 //! Then you can build and instance of the engine using the [EngineBuilder].
-//! The `EngineBuilder::with_default_scheduler()` method will give you the default
+//! The `EngineBuilder::new()` method will give you the default
 //! [FixedUpdateScheduler](crate::scheduler::FixedUpdateScheduler).  The default settings
 //! should be okay for most games.
 //!
@@ -27,27 +27,7 @@
 //! # let context = ContextBuilder::new()
 //! #    .build();
 //! #
-//! let engine = EngineBuilder::with_default_scheduler()
-//!     // Custom settings go here.
-//!     .build(context);
-//! ```
-//!
-//! If you want to customize the [FixedUpdateScheduler](crate::scheduler::FixedUpdateScheduler),
-//! you can build an instance yourself using the
-//! [FixedUpdateSchedulerBuilder](crate::scheduler::FixedUpdateSchedulerBuilder), then pass
-//! it to `EngineBuilder::with_fixed_scheduler()`.
-//!
-//! ```
-//! # use wolf_engine::{ContextBuilder, EngineBuilder, scheduler::FixedUpdateSchedulerBuilder};
-//! #
-//! # let context = ContextBuilder::new()
-//! #    .build();
-//! #
-//! let scheduler = FixedUpdateSchedulerBuilder::new()
-//!     // Custom settings go here.
-//!     .build();
-//!
-//! let engine = EngineBuilder::with_fixed_scheduler(scheduler)
+//! let engine = EngineBuilder::new()
 //!     // Custom settings go here.
 //!     .build(context);
 //! ```
@@ -63,7 +43,7 @@
 //! # let context = ContextBuilder::new()
 //! #    .build();
 //! #
-//! # let engine = EngineBuilder::with_default_scheduler()
+//! # let engine = EngineBuilder::new()
 //! #    .build(context);
 //! #
 //! # let state = EmptyState;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!```
 //!
 //! Then you can build and instance of the engine using the [EngineBuilder].
-//! The `EngineBuilder::new()` method will give you the default
+//! The [EngineBuilder::new()] method will give you the default
 //! [FixedUpdateScheduler](crate::scheduler::FixedUpdateScheduler).  The default settings
 //! should be okay for most games.
 //!

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -83,7 +83,7 @@ pub type Frames = u64;
 /// #   .build();
 /// #
 /// let engine = EngineBuilder::new()
-///     .with_scheduler(custom_scheduler)
+///     .with_scheduler(Box::from(custom_scheduler))
 ///     .build(context);
 /// ```
 pub trait Scheduler {

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -6,6 +6,9 @@ pub use fixed_update_scheduler::*;
 
 use crate::{Context, State};
 
+#[cfg(test)]
+use mockall::automock;
+
 /// Represents the number of ticks the engine has run.
 pub type Ticks = u64;
 
@@ -86,6 +89,7 @@ pub type Frames = u64;
 ///     .with_scheduler(Box::from(custom_scheduler))
 ///     .build(context);
 /// ```
+#[cfg_attr(test, automock)]
 pub trait Scheduler {
     /// Update the game state.
     fn update(&mut self, context: &mut Context, state: &mut dyn State);

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -67,7 +67,7 @@ pub type Frames = u64;
 /// ```
 ///
 /// You can use a custom [Scheduler](crate::scheduler::Scheduler) implementation by using
-/// the `EngineBuilder::with_custom_scheduler()` method.
+/// the `EngineBuilder::with_scheduler()` method.
 ///
 /// ```
 /// # use wolf_engine::{
@@ -82,7 +82,8 @@ pub type Frames = u64;
 /// # let custom_scheduler = FixedUpdateSchedulerBuilder::new()
 /// #   .build();
 /// #
-/// let engine = EngineBuilder::with_custom_scheduler(custom_scheduler)
+/// let engine = EngineBuilder::new()
+///     .with_scheduler(custom_scheduler)
 ///     .build(context);
 /// ```
 pub trait Scheduler {


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->
This PR renames the main engine type, and greatly simplifies the initialization process.

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

<!-- Select one (Delete the rest): -->

- Minor

<!--
Guidelines: 

- Non-Code: Changes are not to the code base.
- Patch: Changes do not effect the public API.
- Minor: Any changes to the public API before version 1.0, or backwards-compatible changes to the public API after version 1.0.
- Major: Any non-backwards-compatible change to the public API after version 1.0.  
 
Be aware that we will be unwilling to accept Major changes without careful consideration and a **VERY** good reason.
-->

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Renamed `WolfEngine` to `Engine`.
- [x] Renamed `WolfEngineBuilder` to `EngineBuilder`.
- [x] Simplified the initialization process.
  - [x] Replaced generic type parameters with `Box`ed trait objects.
  - [x] `Engine::new()` now returns the default instance of the `Engine`.
  - [x] Added `Default` implementation for the Engine.
  - [x] Replaced `EngineBuilder::with_*_scheduler` constructors with a single `with_scheduler` method. 
- [x] Removed currently unused `Winit` integration.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All compiler warnings have been resolved.
  - [x] All Clippy warnings have been resolved (run `cargo clippy`.)
- [ ] Documentation
  - [x] The documentation has been updated.
  - [x] Relavent examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch.
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
