### PR TITLE
Refactor/use anymap crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wolf_engine"
 description = "A game framework with a focus on flexibility and ease of use."
-version = "0.9.0"
+version = "0.9.1"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/AlexiWolf/wolf_engine"
 
 [dependencies]
 log = "0.4"
+anymap = "0.12"
 
 # Optional Dependencies
 simple_logger = {version = "1.13", optional = true}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -14,7 +14,7 @@ pub trait Subcontext: 'static {}
 /// Provides storage and controlled access to global [Engine](crate::Engine) state.
 ///
 /// The context object essentially provides a dynamic container for [Subcontext] objects. 
-/// [Subcontext]s store data used by the engine, engine modules, or the end-user's game.
+/// [Subcontext]s store data used by the engine, engine modules, or the game.
 /// Specific [Subcontext]s can be dynamically added, and retrieved by type, at runtime, 
 /// allowing for greatly improved flexibility, as any type implementing the [Subcontext] 
 /// trait can be used.  An [AnyMap] is used to achieve this behavior.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -19,18 +19,7 @@ pub trait Subcontext: 'static {}
 ///
 /// The data and state stored by the context object is provided by a number of
 /// [Subcontext] objects attached to it.  These [Subcontext]s are added at runtime rather
-/// than compile time.
-///
-/// This works by storing the [Subcontext] as a [Box]ed dyn [Any] object in a map with the
-/// [TypeId] of the object is used as the key.  When accessing a stored [Subcontext]
-/// object, you must provide the type (`T`) of the object you'd like to access, then
-/// the [TypeId] of `T` is used to lookup the corresponding [Subcontext] in the map.  The
-/// object is then down-casted back to `T` and returned to the caller
-///
-/// Because the [TypeId] of the [Subcontext] object is used as the look-up key, there can
-/// be only one instance of a specific [Subcontext] type added to the context at a time.
-/// Attempting to add another [Subcontext] object with a [TypeId] that's already present
-/// in the map will result in a panic.
+/// than compile time allowing for greater flexibility.
 ///
 /// # Examples
 ///

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -13,13 +13,11 @@ pub trait Subcontext: 'static {}
 
 /// Provides storage and controlled access to global [Engine](crate::Engine) state.
 ///
-/// The context object stores global state for the [Engine](crate::Engine).  Any types
-/// that need to work with the [Engine](crate::Engine) can do so through the context
-/// object.  Most utility functions will use the context object to do their work.
-///
-/// The data and state stored by the context object is provided by a number of
-/// [Subcontext] objects attached to it.  These [Subcontext]s are added at runtime rather
-/// than compile time allowing for greater flexibility.
+/// The context object essentially provides a dynamic container for [Subcontext] objects. 
+/// [Subcontext]s store data used by the engine, engine modules, or the end-user's game.
+/// Specific [Subcontext]s can be dynamically added, and retrieved by type, at runtime, 
+/// allowing for greatly improved flexibility, as any type implementing the [Subcontext] 
+/// trait can be used.  An [AnyMap] is used to achieve this behavior.
 ///
 /// # Examples
 ///

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -29,7 +29,7 @@ pub trait Subcontext: 'static {}
 /// let context = Context::default();
 /// ```
 ///
-/// Adding contexts is done using the [Context::add_subcontext()] method.
+/// Adding a [Subcontext] is done using the [Context::add_subcontext()] method.
 ///
 /// ```
 /// # use wolf_engine::context::*;
@@ -41,6 +41,29 @@ pub trait Subcontext: 'static {}
 /// #
 /// context.add_subcontext(my_subcontext);
 /// ```
+///
+/// The [Subcontext] can be accessed again using [Context::get_subcontext()] or 
+/// [Context::get_subcontext_mut()].
+///
+/// ```
+/// # use wolf_engine::context::*;
+/// # 
+/// # struct MySubcontext;
+/// # impl Subcontext for MySubcontext {} 
+/// # let subcontext = MySubcontext;
+/// # let mut context = Context::empty();
+/// # context.add_subcontext(subcontext);
+/// #
+/// // If you want an immutable reference:
+/// if let Some(my_subcontext) = context.get_subcontext::<MySubcontext>() {
+///     // Do something with the Subcontext.
+/// }
+/// 
+/// // If you want a mutable reference:
+/// if let Some(my_subcontext_mut) = context.get_subcontext_mut::<MySubcontext>() {
+///     // Do something with the Subcontext.
+/// }
+///
 pub struct Context {
     subcontexts: AnyMap,
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -28,6 +28,19 @@ pub trait Subcontext: 'static {}
 /// #
 /// let context = Context::default();
 /// ```
+///
+/// Adding contexts is done using the [Context::add_subcontext()] method.
+///
+/// ```
+/// # use wolf_engine::context::*;
+/// # 
+/// # struct MySubcontext;
+/// # impl Subcontext for MySubcontext {} 
+/// # let my_subcontext = MySubcontext;
+/// # let mut context = Context::empty();
+/// #
+/// context.add_subcontext(my_subcontext);
+/// ```
 pub struct Context {
     subcontexts: AnyMap,
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -31,7 +31,7 @@ pub trait Subcontext: 'static {}
 /// let context = Context::default();
 /// ```
 pub struct Context {
-    subcontexts: AnyMap, 
+    subcontexts: AnyMap,
 }
 
 impl Context {


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

This PR refactors the `Context` object to store `Subcontext`s in an [Anymap]() rather than spinning a half-baked custom solution that does essentially the same thing.  No public behavior or APIs have been changed.

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

<!-- Select one (Delete the rest): -->

- Patch

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Replaced the custom `HashMap`-based `Context` implementation with one backed by `AnyMap`.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All compiler warnings have been resolved.
  - [x] All Clippy warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relavent examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch.
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
