### PR TITLE
Feature/state change functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wolf_engine"
 description = "A game framework with a focus on flexibility and ease of use."
-version = "0.10.0"
+version = "0.11.0"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -171,6 +171,7 @@ mod wolf_engine_tests {
             .times(1..)
             .returning(|_| Some(Transition::Quit));
         state.expect_render().times(1..).returning(|_| ());
+        state.expect_shutdown().times(1).returning(|_| ());
 
         wolf_engine.run(Box::from(state));
     }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -165,6 +165,7 @@ mod wolf_engine_tests {
     fn should_run_the_state() {
         let wolf_engine = Engine::default();
         let mut state = MockState::new();
+        state.expect_setup().times(..).returning(|_| ());
         state
             .expect_update()
             .times(1..)

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -83,7 +83,7 @@ impl Engine {
 
     /// Takes ownership over the engine and runs until the [CoreFunction] exits.
     pub fn run(mut self, initial_state: Box<dyn State>) {
-        self.state_stack.push(initial_state);
+        self.state_stack.push(initial_state, &mut self.context);
         let (engine, core_function) = self.extract_core_function();
         (core_function)(engine);
     }

--- a/src/core/state/mod.rs
+++ b/src/core/state/mod.rs
@@ -55,6 +55,9 @@ pub trait State {
     
     /// Run one-time setup after the state is removed.
     fn shutdown(&mut self, _context: &mut Context) {}
+    
+    /// Runs any time the state is deactivated.  
+    fn pause(&mut self, _context: &mut Context) {}
 
     /// Update the game state.
     fn update(&mut self, context: &mut Context) -> OptionalTransition;

--- a/src/core/state/mod.rs
+++ b/src/core/state/mod.rs
@@ -49,16 +49,15 @@ pub type RenderResult = ();
 /// ```
 #[cfg_attr(test, automock)]
 pub trait State {
-
     /// Run one-time setup before the state is run.
     fn setup(&mut self, _context: &mut Context) {}
-    
+
     /// Run one-time setup after the state is removed.
     fn shutdown(&mut self, _context: &mut Context) {}
-    
+
     /// Runs any time the state is deactivated.  
     fn pause(&mut self, _context: &mut Context) {}
-    
+
     /// Runs any time the state is reactivated.
     fn resume(&mut self, _context: &mut Context) {}
 

--- a/src/core/state/mod.rs
+++ b/src/core/state/mod.rs
@@ -50,15 +50,45 @@ pub type RenderResult = ();
 #[cfg_attr(test, automock)]
 pub trait State {
     /// Run one-time setup before the state is run.
+    ///
+    /// There are no specific requirements for this method.  You may use it to do whatever
+    /// your game needs.
+    ///
+    /// This method should be run only once throughout the life of the state object, and 
+    /// before any other method is run.
     fn setup(&mut self, _context: &mut Context) {}
 
-    /// Run one-time setup after the state is removed.
+    /// Run one-time cleanup after the state is removed.
+    ///
+    /// There are no specific requirements for this method.  You may use it to do whatever
+    /// your game needs.
+    ///
+    /// This method should be run only once throughout the life of the state object, and 
+    /// before any other method is run.
     fn shutdown(&mut self, _context: &mut Context) {}
 
-    /// Runs any time the state is deactivated.  
+    /// Pause the game state.
+    ///
+    /// There are no specific requirements for this method.  You may use it to do whatever
+    /// your game needs.
+    ///
+    /// By default this method runs when: 
+    ///
+    /// - The [StateStack] deactivates the state.
+    /// - The application has gone out of focus (such as when the user switches apps on 
+    ///   mobile.)
     fn pause(&mut self, _context: &mut Context) {}
-
-    /// Runs any time the state is reactivated.
+    
+    /// Resume the game state.
+    ///
+    /// There are no specific requirements for this method.  You may use it to do whatever
+    /// your game needs.
+    ///
+    /// By default this method runs when: 
+    ///
+    /// - The [StateStack] reactivates the state.
+    /// - The application has come back into focus (such as when the user switches apps on 
+    ///   mobile.)
     fn resume(&mut self, _context: &mut Context) {}
 
     /// Update the game state.

--- a/src/core/state/mod.rs
+++ b/src/core/state/mod.rs
@@ -49,8 +49,11 @@ pub type RenderResult = ();
 /// ```
 #[cfg_attr(test, automock)]
 pub trait State {
-    fn setup(&mut self, context: &mut Context) {}
 
+    /// Run one-time setup before the state is run.
+    fn setup(&mut self, _context: &mut Context) {}
+    
+    /// Run one-time setup after the state is removed.
     fn shutdown(&mut self, _context: &mut Context) {}
 
     /// Update the game state.

--- a/src/core/state/mod.rs
+++ b/src/core/state/mod.rs
@@ -49,6 +49,8 @@ pub type RenderResult = ();
 /// ```
 #[cfg_attr(test, automock)]
 pub trait State {
+    fn setup(&mut self, context: &mut Context) {}
+
     /// Update the game state.
     fn update(&mut self, context: &mut Context) -> OptionalTransition;
 

--- a/src/core/state/mod.rs
+++ b/src/core/state/mod.rs
@@ -51,6 +51,8 @@ pub type RenderResult = ();
 pub trait State {
     fn setup(&mut self, context: &mut Context) {}
 
+    fn shutdown(&mut self, _context: &mut Context) {}
+
     /// Update the game state.
     fn update(&mut self, context: &mut Context) -> OptionalTransition;
 

--- a/src/core/state/mod.rs
+++ b/src/core/state/mod.rs
@@ -58,6 +58,9 @@ pub trait State {
     
     /// Runs any time the state is deactivated.  
     fn pause(&mut self, _context: &mut Context) {}
+    
+    /// Runs any time the state is reactivated.
+    fn resume(&mut self, _context: &mut Context) {}
 
     /// Update the game state.
     fn update(&mut self, context: &mut Context) -> OptionalTransition;

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -125,7 +125,7 @@ impl StateStack {
     fn pop(&mut self, context: &mut Context) -> Option<Box<dyn State>> {
         if let Some(mut state) = self.stack.pop() {
             self.resume_active_state(context);
-            state.shutdown(context); 
+            state.shutdown(context);
             Some(state)
         } else {
             None
@@ -246,7 +246,10 @@ mod state_stack_tests {
     fn should_not_be_empty_if_there_are_states_on_the_stack() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
 
-        state_stack.push(Box::from(new_mock_state_with_setup_expectation()), &mut context);
+        state_stack.push(
+            Box::from(new_mock_state_with_setup_expectation()),
+            &mut context,
+        );
 
         assert!(!state_stack.is_empty());
     }
@@ -254,7 +257,10 @@ mod state_stack_tests {
     #[test]
     fn should_have_active_state_accessor() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
-        state_stack.push(Box::from(new_mock_state_with_setup_expectation()), &mut context);
+        state_stack.push(
+            Box::from(new_mock_state_with_setup_expectation()),
+            &mut context,
+        );
 
         let state = state_stack.active_mut();
 
@@ -403,9 +409,7 @@ mod state_stack_tests {
     fn should_run_startup_method_when_state_is_added() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
         let mut state = MockState::new();
-        state.expect_setup()
-            .times(1)
-            .returning(|_| ());
+        state.expect_setup().times(1).returning(|_| ());
 
         state_stack.push(Box::from(state), &mut context);
     }
@@ -426,7 +430,7 @@ mod state_stack_tests {
         let mut state_a = new_mock_state_with_setup_expectation();
         let state_b = new_mock_state_with_setup_expectation();
         expect_pause(&mut state_a);
-        
+
         state_stack.push(Box::from(state_a), &mut context);
         state_stack.push(Box::from(state_b), &mut context);
     }

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -96,7 +96,8 @@ impl StateStack {
     /// Push the provided [State] to the top of the stack.
     ///
     /// The state will become the new active state.
-    pub fn push(&mut self, state: Box<dyn State>, context: &mut Context) {
+    pub fn push(&mut self, mut state: Box<dyn State>, context: &mut Context) {
+        state.setup(context);
         self.stack.push(state);
     }
 

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -424,6 +424,15 @@ mod state_stack_tests {
         state_stack.push(Box::from(state_b), &mut context);
     }
 
+    #[test]
+    fn should_run_resume_method_when_state_is_reactivated() {
+        let (mut context, mut state_stack) = new_context_and_state_stack();
+        let mut state_a = new_mock_state_with_setup_expectation();
+        let state_b = new_mock_state_with_setup_expectation();
+        expect_pause(&mut state_a);
+        state_a.expect_resume().times(1).returning(|_| ());
+    }
+
     fn new_context_and_state_stack() -> (Context, StateStack) {
         let context = Context::new();
         let state_stack = StateStack::new();

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -1,7 +1,6 @@
 use std::{fmt::Display, iter::Take, slice::IterMut};
 
 use crate::{Context, OptionalTransition, RenderResult, State, Transition};
-
 /// Provides a stack for storing, managing, and running multiple [State] objects.
 ///
 /// The state stack acts as a common interface through which numerous [State]s can be run
@@ -412,8 +411,12 @@ mod state_stack_tests {
 
     fn new_mock_state_with_setup_expectation() -> MockState {
         let mut state = MockState::new();
-        state.expect_setup().times(..).returning(|_| ());
+        expect_startup(&mut state);
         state
+    }
+
+    fn expect_startup(state: &mut MockState) {
+        state.expect_setup().times(..).returning(|_| ());
     }
 
     fn expect_shutdown(state: &mut MockState) {

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -428,9 +428,14 @@ mod state_stack_tests {
     fn should_run_resume_method_when_state_is_reactivated() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
         let mut state_a = new_mock_state_with_setup_expectation();
-        let state_b = new_mock_state_with_setup_expectation();
+        let mut state_b = new_mock_state_with_setup_expectation();
         expect_pause(&mut state_a);
+        expect_shutdown(&mut state_b);
         state_a.expect_resume().times(1).returning(|_| ());
+
+        state_stack.push(Box::from(state_a), &mut context);
+        state_stack.push(Box::from(state_b), &mut context);
+        state_stack.pop(&mut context);
     }
 
     fn new_context_and_state_stack() -> (Context, StateStack) {

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -96,6 +96,9 @@ impl StateStack {
     ///
     /// The state will become the new active state.
     pub fn push(&mut self, mut state: Box<dyn State>, context: &mut Context) {
+        if let Some(active_state) = self.active_mut() {
+            active_state.pause(context);
+        }
         state.setup(context);
         self.stack.push(state);
     }

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -117,7 +117,12 @@ impl StateStack {
     }
 
     fn pop(&mut self, context: &mut Context) -> Option<Box<dyn State>> {
-        self.stack.pop()
+        if let Some(mut state) = self.stack.pop() {
+            state.shutdown(context); 
+            Some(state)
+        } else {
+            None
+        }
     }
 
     fn clean_push(&mut self, state: Box<dyn State>, context: &mut Context) {

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -375,7 +375,7 @@ mod state_stack_tests {
     #[test]
     fn should_run_startup_method_when_state_is_added() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
-        let state = MockState::new();
+        let mut state = MockState::new();
         state.expect_setup()
             .times(1)
             .returning(|_| ());

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -96,7 +96,7 @@ impl StateStack {
     /// Push the provided [State] to the top of the stack.
     ///
     /// The state will become the new active state.
-    pub fn push(&mut self, state: Box<dyn State>) {
+    pub fn push(&mut self, state: Box<dyn State>, context: &mut Context) {
         self.stack.push(state);
     }
 

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -195,7 +195,7 @@ mod state_stack_tests {
         let (mut context, mut state_stack) = new_context_and_state_stack();
         let state = MockState::new();
 
-        state_stack.push(Box::from(state), context);
+        state_stack.push(Box::from(state), &mut context);
 
         assert_eq!(
             state_stack.stack.len(),

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -372,6 +372,17 @@ mod state_stack_tests {
         }
     }
 
+    #[test]
+    fn should_run_startup_method_when_state_is_added() {
+        let (_, mut state_stack) = new_context_and_state_stack();
+        let state = MockState::new();
+        state.expect_setup()
+            .times(1)
+            .returning(|_| ());
+
+        state_stack.push(state);
+    }
+
     fn new_context_and_state_stack() -> (Context, StateStack) {
         let context = Context::new();
         let state_stack = StateStack::new();

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -116,7 +116,7 @@ impl StateStack {
         self.pop();
     }
 
-    fn pop(&mut self) -> Option<Box<dyn State>> {
+    fn pop(&mut self, context: &mut Context) -> Option<Box<dyn State>> {
         self.stack.pop()
     }
 

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -374,13 +374,13 @@ mod state_stack_tests {
 
     #[test]
     fn should_run_startup_method_when_state_is_added() {
-        let (_, mut state_stack) = new_context_and_state_stack();
+        let (mut context, mut state_stack) = new_context_and_state_stack();
         let state = MockState::new();
         state.expect_setup()
             .times(1)
             .returning(|_| ());
 
-        state_stack.push(state);
+        state_stack.push(state, &mut context);
     }
 
     fn new_context_and_state_stack() -> (Context, StateStack) {

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -112,8 +112,8 @@ impl StateStack {
         }
     }
 
-    fn pop_no_return(&mut self) {
-        self.pop();
+    fn pop_no_return(&mut self, context: &mut Context) {
+        self.pop(context);
     }
 
     fn pop(&mut self, context: &mut Context) -> Option<Box<dyn State>> {

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -96,11 +96,15 @@ impl StateStack {
     ///
     /// The state will become the new active state.
     pub fn push(&mut self, mut state: Box<dyn State>, context: &mut Context) {
+        self.pause_active_state(context);
+        state.setup(context);
+        self.stack.push(state);
+    }
+
+    fn pause_active_state(&mut self, context: &mut Context) {
         if let Some(active_state) = self.active_mut() {
             active_state.pause(context);
         }
-        state.setup(context);
-        self.stack.push(state);
     }
 
     fn do_transition(&mut self, update_result: OptionalTransition, context: &mut Context) {

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -416,7 +416,7 @@ mod state_stack_tests {
     }
 
     fn expect_startup(state: &mut MockState) {
-        state.expect_setup().times(..).returning(|_| ());
+        state.expect_setup().times(0..2).returning(|_| ());
     }
 
     fn expect_shutdown(state: &mut MockState) {

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -125,6 +125,9 @@ impl StateStack {
     fn pop(&mut self, context: &mut Context) -> Option<Box<dyn State>> {
         if let Some(mut state) = self.stack.pop() {
             state.shutdown(context); 
+            if let Some(active_state) = self.active_mut() {
+                active_state.resume(context);
+            }
             Some(state)
         } else {
             None

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -194,7 +194,7 @@ mod state_stack_tests {
     #[test]
     fn should_push_state_on_the_stack() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
-        let state = MockState::new();
+        let state = new_mock_state_with_setup_expectation();
 
         state_stack.push(Box::from(state), &mut context);
 
@@ -208,8 +208,7 @@ mod state_stack_tests {
     #[test]
     fn should_pop_state_off_the_stack() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
-        state_stack.push(Box::from(MockState::new()), &mut context);
-
+        state_stack.push(Box::from(new_mock_state_with_setup_expectation()), &mut context);
         let state = state_stack.pop();
 
         assert!(state.is_some(), "No state was returned");
@@ -226,7 +225,7 @@ mod state_stack_tests {
     fn should_not_be_empty_if_there_are_states_on_the_stack() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
 
-        state_stack.push(Box::from(MockState::new()), &mut context);
+        state_stack.push(Box::from(new_mock_state_with_setup_expectation()), &mut context);
 
         assert!(!state_stack.is_empty());
     }
@@ -234,7 +233,7 @@ mod state_stack_tests {
     #[test]
     fn should_have_active_state_accessor() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
-        state_stack.push(Box::from(MockState::new()), &mut context);
+        state_stack.push(Box::from(new_mock_state_with_setup_expectation()), &mut context);
 
         let state = state_stack.active_mut();
 
@@ -244,7 +243,7 @@ mod state_stack_tests {
     #[test]
     fn should_handle_none_transition() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
-        let mut state = MockState::new();
+        let mut state = new_mock_state_with_setup_expectation();
         state.expect_update().times(3).returning(|_| None);
 
         state_stack.push(Box::from(state), &mut context);
@@ -256,7 +255,7 @@ mod state_stack_tests {
     #[test]
     fn should_handle_pop_transition() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
-        let mut state = MockState::new();
+        let mut state = new_mock_state_with_setup_expectation();
         state
             .expect_update()
             .times(1)
@@ -271,8 +270,8 @@ mod state_stack_tests {
     #[test]
     fn should_handle_to_state_transition() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
-        let mut transition_to_state = MockState::new();
-        let mut no_transition = MockState::new();
+        let mut transition_to_state = new_mock_state_with_setup_expectation();
+        let mut no_transition = new_mock_state_with_setup_expectation();
         no_transition.expect_update().times(9).returning(|_| None);
         transition_to_state
             .expect_update()
@@ -292,12 +291,12 @@ mod state_stack_tests {
     #[test]
     fn should_handle_clean_push_transition() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
-        let mut no_transition_state = MockState::new();
+        let mut no_transition_state = new_mock_state_with_setup_expectation();
         no_transition_state
             .expect_update()
             .times(1)
             .returning(|_| None);
-        let mut clean_push_state = MockState::new();
+        let mut clean_push_state = new_mock_state_with_setup_expectation();
         clean_push_state
             .expect_update()
             .times(1)
@@ -312,7 +311,7 @@ mod state_stack_tests {
     #[test]
     fn should_handle_quit_transition() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
-        let mut quit_state = MockState::new();
+        let mut quit_state = new_mock_state_with_setup_expectation();
         quit_state
             .expect_update()
             .times(1)
@@ -330,12 +329,12 @@ mod state_stack_tests {
     #[test]
     fn should_run_background_update_for_background_states() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
-        let mut state_a = MockState::new();
+        let mut state_a = new_mock_state_with_setup_expectation();
         state_a
             .expect_background_update()
             .times(10)
             .returning(|_| ());
-        let mut state_b = MockState::new();
+        let mut state_b = new_mock_state_with_setup_expectation();
         state_b.expect_update().times(10).returning(|_| None);
         state_stack.push(Box::from(state_a), &mut context);
         state_stack.push(Box::from(state_b), &mut context);
@@ -348,12 +347,12 @@ mod state_stack_tests {
     #[test]
     fn should_run_background_render_for_background_states() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
-        let mut state_a = MockState::new();
+        let mut state_a = new_mock_state_with_setup_expectation();
         state_a
             .expect_background_render()
             .times(10)
             .returning(|_| ());
-        let mut state_b = MockState::new();
+        let mut state_b = new_mock_state_with_setup_expectation();
         state_b.expect_render().times(10).returning(|_| ());
         state_stack.push(Box::from(state_a), &mut context);
         state_stack.push(Box::from(state_b), &mut context);
@@ -388,5 +387,11 @@ mod state_stack_tests {
         let context = Context::new();
         let state_stack = StateStack::new();
         (context, state_stack)
+    }
+
+    fn new_mock_state_with_setup_expectation() -> MockState {
+        let mut state = MockState::new();
+        state.expect_setup().times(..).returning(|_| ());
+        state
     }
 }

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -383,6 +383,15 @@ mod state_stack_tests {
         state_stack.push(Box::from(state), &mut context);
     }
 
+    #[test]
+    fn should_run_shutdown_method_when_state_is_removed() {
+        let (mut context, mut state_stack) = new_context_and_state_stack();
+        let mut state = new_mock_state_with_setup_expectation();
+        state.expect_shutdown().times(1).returning(|_| ());
+
+        state_stack.pop();
+    }
+
     fn new_context_and_state_stack() -> (Context, StateStack) {
         let context = Context::new();
         let state_stack = StateStack::new();

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -403,6 +403,14 @@ mod state_stack_tests {
         state_stack.pop(&mut context);
     }
 
+    #[test]
+    fn should_run_pause_method_when_state_is_deactivated() {
+        let (mut context, mut state_stack) = new_context_and_state_stack();
+        let mut state_a = new_mock_state_with_setup_expectation();
+        let mut state_b = new_mock_state_with_setup_expectation();
+        state_b.expect_pause().times(1).returning(|_| ());
+    }
+
     fn new_context_and_state_stack() -> (Context, StateStack) {
         let context = Context::new();
         let state_stack = StateStack::new();

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -105,9 +105,9 @@ impl StateStack {
         if let Some(transition) = update_result {
             match transition {
                 Transition::Push(state) => self.push(state, context),
-                Transition::Pop => self.pop_no_return(),
+                Transition::Pop => self.pop_no_return(context),
                 Transition::CleanPush(state) => self.clean_push(state, context),
-                Transition::Quit => self.clear(),
+                Transition::Quit => self.clear(context),
             }
         }
     }
@@ -121,14 +121,14 @@ impl StateStack {
     }
 
     fn clean_push(&mut self, state: Box<dyn State>, context: &mut Context) {
-        self.clear();
+        self.clear(context);
         self.push(state, context);
     }
 
     /// Pop all states off the stack.
-    pub fn clear(&mut self) {
+    pub fn clear(&mut self, context: &mut Context) {
         while !self.is_empty() {
-            self.pop();
+            self.pop(context);
         }
     }
 

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -407,8 +407,11 @@ mod state_stack_tests {
     fn should_run_pause_method_when_state_is_deactivated() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
         let mut state_a = new_mock_state_with_setup_expectation();
-        let mut state_b = new_mock_state_with_setup_expectation();
-        state_b.expect_pause().times(1).returning(|_| ());
+        let state_b = new_mock_state_with_setup_expectation();
+        state_a.expect_pause().times(1).returning(|_| ());
+        
+        state_stack.push(Box::from(state_a), &mut context);
+        state_stack.push(Box::from(state_b), &mut context);
     }
 
     fn new_context_and_state_stack() -> (Context, StateStack) {

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -23,23 +23,28 @@ use crate::{Context, OptionalTransition, RenderResult, State, Transition};
 ///
 /// # Active State
 ///
-/// The "active" state is whatever state is currently on the top of the stack.  Active
-/// states have the following properties:
+/// The "active" state is whatever state is currently on the top of the stack.  When a 
+/// state becomes the top state, it is "reactivated." Active states have the following 
+/// properties:
 ///
 /// - Only the active state will have it's "foreground" `[update/render]` methods called.
 /// - The active state will not have it's `background_[update/render]` methods called.
 /// - The active state is the only stat that can send a [Transition] to the state stack.
+/// - Active states wil have their [State::resume()] method called first thing when they 
+///   are reactivated.
 ///
 /// Normally, the active state is going to be the "mode" your game is in.
 ///
 /// # Inactive States
 ///
-/// A state is designated as "inactive" when it's not on the top of the stack.  Inactive
-/// states have the following properties:
+/// A state is designated as "inactive" (or is "deactivated") when it's not on the top 
+/// of the stack.  Inactive states have the following properties:
 ///
 /// - Inactive states will only have their `background_[update/render]` methods called.
 /// - Inactive states will not have their "foreground" `[update/render]` methods called.
 /// - Inactive states cannot send a [Transition] to the state stack.
+/// - Inactive states will have their [State::pause()] method called first thing when 
+///   they are deactivated.
 ///
 /// # Update / Render Order
 ///

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -380,7 +380,7 @@ mod state_stack_tests {
             .times(1)
             .returning(|_| ());
 
-        state_stack.push(state, &mut context);
+        state_stack.push(Box::from(state), &mut context);
     }
 
     fn new_context_and_state_stack() -> (Context, StateStack) {

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -92,6 +92,17 @@ impl StateStack {
         self.stack.last_mut()
     }
 
+    fn do_transition(&mut self, update_result: OptionalTransition, context: &mut Context) {
+        if let Some(transition) = update_result {
+            match transition {
+                Transition::Push(state) => self.push(state, context),
+                Transition::Pop => self.pop_no_return(context),
+                Transition::CleanPush(state) => self.clean_push(state, context),
+                Transition::Quit => self.clear(context),
+            }
+        }
+    }
+
     /// Push the provided [State] to the top of the stack.
     ///
     /// The state will become the new active state.
@@ -104,17 +115,6 @@ impl StateStack {
     fn pause_active_state(&mut self, context: &mut Context) {
         if let Some(active_state) = self.active_mut() {
             active_state.pause(context);
-        }
-    }
-
-    fn do_transition(&mut self, update_result: OptionalTransition, context: &mut Context) {
-        if let Some(transition) = update_result {
-            match transition {
-                Transition::Push(state) => self.push(state, context),
-                Transition::Pop => self.pop_no_return(context),
-                Transition::CleanPush(state) => self.clean_push(state, context),
-                Transition::Quit => self.clear(context),
-            }
         }
     }
 

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -124,13 +124,17 @@ impl StateStack {
 
     fn pop(&mut self, context: &mut Context) -> Option<Box<dyn State>> {
         if let Some(mut state) = self.stack.pop() {
+            self.resume_active_state(context);
             state.shutdown(context); 
-            if let Some(active_state) = self.active_mut() {
-                active_state.resume(context);
-            }
             Some(state)
         } else {
             None
+        }
+    }
+
+    fn resume_active_state(&mut self, context: &mut Context) {
+        if let Some(active_state) = self.active_mut() {
+            active_state.resume(context);
         }
     }
 

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -389,7 +389,7 @@ mod state_stack_tests {
         let mut state = new_mock_state_with_setup_expectation();
         state.expect_shutdown().times(1).returning(|_| ());
 
-        state_stack.pop();
+        state_stack.pop(&mut context);
     }
 
     fn new_context_and_state_stack() -> (Context, StateStack) {

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -292,6 +292,7 @@ mod state_stack_tests {
             .expect_background_update()
             .times(9)
             .returning(|_| ());
+        expect_pause(&mut transition_to_state);
 
         state_stack.push(Box::from(transition_to_state), &mut context);
         for _ in 0..10 {
@@ -347,6 +348,7 @@ mod state_stack_tests {
             .expect_background_update()
             .times(10)
             .returning(|_| ());
+        expect_pause(&mut state_a);
         let mut state_b = new_mock_state_with_setup_expectation();
         state_b.expect_update().times(10).returning(|_| None);
         state_stack.push(Box::from(state_a), &mut context);
@@ -365,6 +367,7 @@ mod state_stack_tests {
             .expect_background_render()
             .times(10)
             .returning(|_| ());
+        expect_pause(&mut state_a);
         let mut state_b = new_mock_state_with_setup_expectation();
         state_b.expect_render().times(10).returning(|_| ());
         state_stack.push(Box::from(state_a), &mut context);
@@ -411,7 +414,7 @@ mod state_stack_tests {
         let (mut context, mut state_stack) = new_context_and_state_stack();
         let mut state_a = new_mock_state_with_setup_expectation();
         let state_b = new_mock_state_with_setup_expectation();
-        state_a.expect_pause().times(1).returning(|_| ());
+        expect_pause(&mut state_a);
         
         state_stack.push(Box::from(state_a), &mut context);
         state_stack.push(Box::from(state_b), &mut context);
@@ -435,5 +438,9 @@ mod state_stack_tests {
 
     fn expect_shutdown(state: &mut MockState) {
         state.expect_shutdown().times(1).returning(|_| ());
+    }
+
+    fn expect_pause(state: &mut MockState) {
+        state.expect_pause().times(1).returning(|_| ());
     }
 }

--- a/src/core/state/state_stack.rs
+++ b/src/core/state/state_stack.rs
@@ -209,7 +209,7 @@ mod state_stack_tests {
     fn should_pop_state_off_the_stack() {
         let (mut context, mut state_stack) = new_context_and_state_stack();
         state_stack.push(Box::from(new_mock_state_with_setup_expectation()), &mut context);
-        let state = state_stack.pop();
+        let state = state_stack.pop(&mut context);
 
         assert!(state.is_some(), "No state was returned");
     }


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

This PR adds setup / shutdown and resume / pause functions to the `State` type.  These methods are used by the `StateStack` when a state change happens.  This closes #46.

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

- Minor

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Added new methods to the `State` trait.
  - [x] Added `setup()` method.
  - [x] Added `shutdown()` method.
  - [x] Added `resume()` method.
  - [x] Added `pause()` method.
- [x] Updated the `StateStack`'s behavior to use the new functions.
  - [x] Made all `StateStack` methods require a `&mut Context` (to pass to the `State` methods.)
  - [x] Made `push()` call `State::setup()` before pushing the `State` to the stack.
  - [x] Made `pop()` call `State::shutdown()` before dropping the `State`.
  - [x] Made `push()` call `State::pause()` on the previously active `State` before pushing the new one to the top of the stack.
  - [x] Made `pop()` call `State::resume()` on the newly active `State` after popping the previous one off the top of the stack.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All compiler warnings have been resolved.
  - [x] All Clippy warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relavent examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch.
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
