### PR TITLE
Feature/plugin system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wolf_engine"
 description = "A game framework with a focus on flexibility and ease of use."
-version = "0.12.0"
+version = "0.13.0"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/custom_engine_core.rs
+++ b/examples/custom_engine_core.rs
@@ -5,10 +5,9 @@ pub fn main() {
     #[cfg(feature = "logging")]
     logging::initialize_logging(LevelFilter::Info);
 
-    let context = Context::default();
     EngineBuilder::new()
         .with_engine_core(Box::from(my_custom_core_function))
-        .build(context)
+        .build()
         .run(Box::from(EmptyState));
 }
 

--- a/examples/custom_subcontexts.rs
+++ b/examples/custom_subcontexts.rs
@@ -5,12 +5,11 @@ pub fn main() {
     #[cfg(feature = "logging")]
     wolf_engine::logging::initialize_logging(LevelFilter::Info);
 
-    let mut context = Context::default();
-    context
+    let engine_builder = EngineBuilder::new();
+    engine_builder.context
         .add(CustomContext::new("Hello, World!"))
         .expect("failed to add subcontext");
-
-    EngineBuilder::new().build(context).run(Box::from(MyState));
+    engine_builder.build().run(Box::from(MyState));
 }
 
 pub struct CustomContext {

--- a/examples/custom_subcontexts.rs
+++ b/examples/custom_subcontexts.rs
@@ -6,7 +6,8 @@ pub fn main() {
     wolf_engine::logging::initialize_logging(LevelFilter::Info);
 
     let mut engine_builder = EngineBuilder::new();
-    engine_builder.context
+    engine_builder
+        .context
         .add(CustomContext::new("Hello, World!"))
         .expect("failed to add subcontext");
     engine_builder.build().run(Box::from(MyState));

--- a/examples/custom_subcontexts.rs
+++ b/examples/custom_subcontexts.rs
@@ -5,7 +5,7 @@ pub fn main() {
     #[cfg(feature = "logging")]
     wolf_engine::logging::initialize_logging(LevelFilter::Info);
 
-    let engine_builder = EngineBuilder::new();
+    let mut engine_builder = EngineBuilder::new();
     engine_builder.context
         .add(CustomContext::new("Hello, World!"))
         .expect("failed to add subcontext");

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,8 +1,8 @@
 use log::*;
 use rc_event_queue::LendingIterator;
-use wolf_engine::*;
 use wolf_engine::contexts::EventContext;
 use wolf_engine::event::EventReader;
+use wolf_engine::*;
 
 pub fn main() {
     #[cfg(feature = "logging")]
@@ -20,7 +20,7 @@ impl State for ExampleState {
     fn setup(&mut self, context: &mut Context) {
         let event_context = EventContext::<usize>::default();
         self.number_reader = Some(event_context.reader());
-        context.add(event_context).unwrap(); 
+        context.add(event_context).unwrap();
     }
 
     fn update(&mut self, context: &mut Context) -> OptionalTransition {
@@ -52,7 +52,8 @@ impl ExampleState {
     }
 
     pub fn get_event_context(context: &Context) -> &EventContext<usize> {
-        context.get::<EventContext<usize>>()
+        context
+            .get::<EventContext<usize>>()
             .expect("the context has no EventContext<usize>")
     }
 }

--- a/examples/plugins.rs
+++ b/examples/plugins.rs
@@ -1,0 +1,54 @@
+use log::*;
+use wolf_engine::*;
+
+pub fn main() {
+    #[cfg(feature = "logging")]
+    logging::initialize_logging(LevelFilter::Info);
+
+    EngineBuilder::new()
+        .with_plugin(Box::from(MessagePlugin::new("Hello, world!")))
+        .build()
+        .run(Box::from(GameState));
+}
+
+pub struct MessagePlugin {
+    message: String,
+}
+
+impl Plugin for MessagePlugin {
+    fn setup(&mut self, engine_builder: EngineBuilder) -> EngineBuilder {
+        engine_builder.with_subcontext(MessageContext::new(self.message.clone()))
+    }
+}
+
+impl MessagePlugin {
+    pub fn new(message: &str) -> Self {
+        Self {
+            message: message.to_string(),
+        }
+    }
+}
+
+pub struct MessageContext {
+    message: String,
+}
+
+impl MessageContext {
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl Subcontext for MessageContext {}
+
+pub struct GameState;
+
+impl State for GameState {
+    fn update(&mut self, context: &mut Context) -> OptionalTransition {
+        let message = context.get::<MessageContext>().unwrap();
+        info!("{}", message.message);
+        Some(Transition::Quit)
+    }
+
+    fn render(&mut self, _context: &mut Context) -> RenderResult {}
+}

--- a/src/contexts/event_context.rs
+++ b/src/contexts/event_context.rs
@@ -7,19 +7,19 @@ use crate::{
 
 /// Provides an event system usable through the [Context](crate::Context).
 ///
-/// The Event Context is a small wrapper around [rc_event_queue]s API.  It helps to 
-/// integrate everything more cleanly into the engine and is a bit more friendly than 
+/// The Event Context is a small wrapper around [rc_event_queue]s API.  It helps to
+/// integrate everything more cleanly into the engine and is a bit more friendly than
 /// using [EventQueue] and [EventReader] directly.
 ///
 /// # Examples
 ///
-/// To create a new Event Context, you should use [EventContext::default()].  You must 
+/// To create a new Event Context, you should use [EventContext::default()].  You must
 /// provide an event type parameter, or a type annotation to indicate which type you want
 /// to use an event.  Most types can be used as an Event.
 ///
 /// ```
 /// # use wolf_engine::contexts::EventContext;
-/// # use wolf_engine::event::Event; 
+/// # use wolf_engine::event::Event;
 /// #
 /// let event_context = EventContext::<Event>::default();
 /// ```
@@ -27,16 +27,16 @@ use crate::{
 ///
 /// ```
 /// # use wolf_engine::contexts::EventContext;
-/// # use wolf_engine::event::Event; 
+/// # use wolf_engine::event::Event;
 /// #
 /// let event_context: EventContext<Event> = EventContext::default();
 /// ```
-/// 
+///
 /// Pushing events is done using [EventContext::push()] like so:
 ///
 /// ```
 /// # use wolf_engine::contexts::EventContext;
-/// # use wolf_engine::event::Event; 
+/// # use wolf_engine::event::Event;
 /// #
 /// # let event_context = EventContext::<usize>::default();
 /// # let event = 0;
@@ -49,7 +49,7 @@ use crate::{
 ///
 /// ```
 /// # use wolf_engine::contexts::EventContext;
-/// # use wolf_engine::event::Event; 
+/// # use wolf_engine::event::Event;
 /// #
 /// # let event_context = EventContext::<usize>::default();
 /// #
@@ -69,17 +69,17 @@ use crate::{
 /// ```
 ///
 /// In most cases, you're not going to be using an Event Context in isolation.  You'll
-/// probably be working with an existing Event Context stored on the 
-/// [Context](crate::Context).  You can access specific Event Contexts through the 
+/// probably be working with an existing Event Context stored on the
+/// [Context](crate::Context).  You can access specific Event Contexts through the
 /// [Context::get()](crate::Context) method.
 ///
-/// **Note:** There are no methods on the Event Context that require a mutable reference, 
+/// **Note:** There are no methods on the Event Context that require a mutable reference,
 /// so make sure you use [Context::get()](crate::Context) for an immutable reference.
 ///
 /// ```
 /// # use wolf_engine::Context;
 /// # use wolf_engine::contexts::EventContext;
-/// # use wolf_engine::event::Event; 
+/// # use wolf_engine::event::Event;
 /// #
 /// # let mut context = Context::empty();
 /// # context.add(EventContext::<Event>::default()).unwrap();
@@ -89,24 +89,24 @@ use crate::{
 ///
 /// # Preventing Memory Leaks
 ///
-/// One of the main problems with using [EventQueue] and [EventReader] directly, is it's 
+/// One of the main problems with using [EventQueue] and [EventReader] directly, is it's
 /// possible to trigger memory leaks if an [EventReader] is created, but not read from.
 /// The [EventQueue] does not drop events unless all of its [EventReader]s have read the
-/// event.  This allows a rogue [EventReader] to cause events to stack up, resulting in 
+/// event.  This allows a rogue [EventReader] to cause events to stack up, resulting in
 /// a memory leak.
 ///
 /// The Event Context helps to prevent this issue by imposing a limit on how many events
-/// the [EventQueue] can contain.  If this limit is exceeded, the oldest events will be 
-/// forcibly removed and dropped.  While this means some events may never be processed, 
+/// the [EventQueue] can contain.  If this limit is exceeded, the oldest events will be
+/// forcibly removed and dropped.  While this means some events may never be processed,
 /// in most cases this is preferable to crashing.
 ///
-/// The best way to ensure the event cap is not reached is to ensure all [EventReader]s 
+/// The best way to ensure the event cap is not reached is to ensure all [EventReader]s
 /// are being read from, and are dropped when you are done with them.
 ///
-/// ## Increasing the Queue Size Limit 
+/// ## Increasing the Queue Size Limit
 ///
 /// The default event cap is about 100K, and in most cases (assuming your game is working
-/// normally), you shouldn't get anywhere near the limit.  If you find the cap isn't 
+/// normally), you shouldn't get anywhere near the limit.  If you find the cap isn't
 /// enough for your game, the cap can be increased using [EventContext::new()].
 ///
 /// ```Rust
@@ -123,10 +123,9 @@ pub struct EventContext<E> {
 }
 
 impl<E> EventContext<E> {
-
     /// Create a new Event Context with a custom queue size limit.
     ///
-    /// If you don't need a custom queue size limit, you should use 
+    /// If you don't need a custom queue size limit, you should use
     /// [EventContext::default()] instead.
     pub fn new(max_queue_size: usize) -> Self {
         Self {
@@ -134,7 +133,7 @@ impl<E> EventContext<E> {
             max_queue_size,
         }
     }
-   
+
     /// Push an event to the event queue.
     ///
     /// This will also check if the queue size has exceeded the maximum and will forcibly

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -139,7 +139,7 @@ impl Context {
     }
 
     pub fn is_empty(&self) -> bool {
-        false 
+        self.subcontexts.is_empty() 
     }
 }
 

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -85,20 +85,9 @@ pub struct Context {
 }
 
 impl Context {
-    /// Create an instance of the default context.
-    ///
-    /// The default context starts off with a few common [Subcontext]s.  If this is not
-    /// desirable, use [Context::empty()].
-    ///
-    /// The default [Subcontext]s:
-    ///
-    /// - [SchedulerContext]
+    /// Create a new context with no [Subcontext]s.
     pub fn new() -> Self {
-        let mut context = Self::empty();
-        context
-            .add(SchedulerContext::new())
-            .expect("failed to add SchedulerContext");
-        context
+        Self::empty()
     }
 
     /// Create an empty context with no [Subcontext]s.

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -148,7 +148,7 @@ impl Context {
     }
 
     pub fn len(&self) -> usize {
-        0
+        self.subcontexts.len()
     }
 }
 

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -7,8 +7,6 @@ use anymap::AnyMap;
 #[cfg(test)]
 use mockall::automock;
 
-use crate::contexts::SchedulerContext;
-
 /// Indicates a [Subcontext] has already been added to the [Context].
 #[derive(Debug)]
 pub struct ContextAlreadyExistsError;
@@ -150,6 +148,13 @@ impl Default for Context {
 #[cfg(test)]
 mod context_tests {
     use super::*;
+
+    #[test]
+    fn should_always_initialize_empty_context_object() {
+        assert_eq!(Context::new().len(), 0, "Context::new() was not empty");
+        assert_eq!(Context::empty().len(), 0, "Context::empty() was not empty");
+        assert_eq!(Context::default().len(), 0, "Context::default() was not empty");
+    }
 
     #[test]
     fn should_add_subcontext() {

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -151,13 +151,9 @@ mod context_tests {
 
     #[test]
     fn should_always_start_with_no_subcontexts() {
-        assert_eq!(Context::new().len(), 0, "Context::new() was not empty");
-        assert_eq!(Context::empty().len(), 0, "Context::empty() was not empty");
-        assert_eq!(
-            Context::default().len(),
-            0,
-            "Context::default() was not empty"
-        );
+        assert_eq!(Context::new().is_empty(), "Context::new() was not empty");
+        assert_eq!(Context::empty().is_empty(), "Context::empty() was not empty");
+        assert_eq!(Context::default().is_empty(), "Context::default() was not empty");
     }
 
     #[test]

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -139,7 +139,7 @@ impl Context {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.subcontexts.is_empty() 
+        self.subcontexts.is_empty()
     }
 }
 
@@ -156,8 +156,14 @@ mod context_tests {
     #[test]
     fn should_always_start_with_no_subcontexts() {
         assert!(Context::new().is_empty(), "Context::new() was not empty");
-        assert!(Context::empty().is_empty(), "Context::empty() was not empty");
-        assert!(Context::default().is_empty(), "Context::default() was not empty");
+        assert!(
+            Context::empty().is_empty(),
+            "Context::empty() was not empty"
+        );
+        assert!(
+            Context::default().is_empty(),
+            "Context::default() was not empty"
+        );
     }
 
     #[test]

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -137,6 +137,10 @@ impl Context {
     pub fn len(&self) -> usize {
         self.subcontexts.len()
     }
+
+    pub fn is_empty() -> bool {
+        false 
+    }
 }
 
 impl Default for Context {

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -153,7 +153,11 @@ mod context_tests {
     fn should_always_start_with_no_subcontexts() {
         assert_eq!(Context::new().len(), 0, "Context::new() was not empty");
         assert_eq!(Context::empty().len(), 0, "Context::empty() was not empty");
-        assert_eq!(Context::default().len(), 0, "Context::default() was not empty");
+        assert_eq!(
+            Context::default().len(),
+            0,
+            "Context::default() was not empty"
+        );
     }
 
     #[test]

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -150,7 +150,7 @@ mod context_tests {
     use super::*;
 
     #[test]
-    fn should_always_initialize_empty_context_object() {
+    fn should_always_start_with_no_subcontexts() {
         assert_eq!(Context::new().len(), 0, "Context::new() was not empty");
         assert_eq!(Context::empty().len(), 0, "Context::empty() was not empty");
         assert_eq!(Context::default().len(), 0, "Context::default() was not empty");

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -155,9 +155,9 @@ mod context_tests {
 
     #[test]
     fn should_always_start_with_no_subcontexts() {
-        assert_eq!(Context::new().is_empty(), "Context::new() was not empty");
-        assert_eq!(Context::empty().is_empty(), "Context::empty() was not empty");
-        assert_eq!(Context::default().is_empty(), "Context::default() was not empty");
+        assert!(Context::new().is_empty(), "Context::new() was not empty");
+        assert!(Context::empty().is_empty(), "Context::empty() was not empty");
+        assert!(Context::default().is_empty(), "Context::default() was not empty");
     }
 
     #[test]

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -146,6 +146,10 @@ impl Context {
     pub fn remove<T: Subcontext>(&mut self) {
         self.subcontexts.remove::<T>();
     }
+
+    pub fn len(&self) -> usize {
+        0
+    }
 }
 
 impl Default for Context {

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -138,7 +138,7 @@ impl Context {
         self.subcontexts.len()
     }
 
-    pub fn is_empty() -> bool {
+    pub fn is_empty(&self) -> bool {
         false 
     }
 }

--- a/src/core/core_function.rs
+++ b/src/core/core_function.rs
@@ -46,11 +46,10 @@ use crate::Engine;
 /// # use wolf_engine::*;
 /// #
 /// # let custom_engine_core = run_while_has_active_state;
-/// # let context = Context::default();
 /// #
 /// let engine = EngineBuilder::new()
 ///     .with_engine_core(Box::from(custom_engine_core))
-///     .build(context);
+///     .build();
 /// ```
 pub type CoreFunction = Box<dyn Fn(Engine)>;
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -112,12 +112,13 @@ impl Engine {
 impl Default for Engine {
     fn default() -> Self {
         let context = Context::default();
-        EngineBuilder::new().build(context)
+        EngineBuilder::new().build()
     }
 }
 
 /// Build and customize an instance of the [Engine].
 pub struct EngineBuilder {
+    context: Context,
     scheduler: Box<dyn Scheduler>,
     core: CoreFunction,
 }
@@ -131,7 +132,7 @@ impl EngineBuilder {
     /// Consumes the engine builder and returns an [Engine] created from it.
     pub fn build(self) -> Engine {
         Engine {
-            context,
+            context: self.context,
             scheduler: self.scheduler,
             state_stack: StateStack::new(),
             core: self.core,
@@ -154,6 +155,7 @@ impl EngineBuilder {
 impl Default for EngineBuilder {
     fn default() -> Self {
         Self {
+            context: Context::default(),
             scheduler: Box::from(FixedUpdateScheduler::default()),
             core: Box::from(run_while_has_active_state),
         }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -255,7 +255,7 @@ mod engine_builder_tests {
             .returning(|_| ());
         
         let _engine = EngineBuilder::new()
-            .with_plugin()
+            .with_plugin(plugin)
             .build();
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -16,7 +16,8 @@ use crate::*;
 /// If you just want to use the defaults, you can use [Engine::new()].
 ///
 /// ```
-/// # use wolf_engine::{Engine, EmptyState};
+/// # use wolf_engine::*;
+/// #
 /// # let my_game_state = EmptyState;
 /// #
 /// let engine = Engine::new();
@@ -25,7 +26,8 @@ use crate::*;
 /// Using [Engine::default()] does the same thing:
 ///
 /// ```
-/// # use wolf_engine::{Engine, EmptyState};
+/// # use wolf_engine::*;
+/// #
 /// # let my_game_state = EmptyState;
 /// #
 /// let engine = Engine::default();
@@ -35,7 +37,7 @@ use crate::*;
 /// can be used to customize just about every aspect of the engine.
 ///
 /// ```
-/// # use wolf_engine::EngineBuilder;
+/// # use wolf_engine::*;
 /// #
 /// // Add to the Context object here.
 /// let engine = EngineBuilder::new()
@@ -51,7 +53,7 @@ use crate::*;
 /// to it.
 ///
 /// ```
-/// # use wolf_engine::{Engine, EmptyState};
+/// # use wolf_engine::*;
 /// #
 /// # let engine = Engine::default();
 /// # let my_game_state = EmptyState;

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -155,6 +155,10 @@ impl EngineBuilder {
     pub fn with_plugin(self, mut plugin: Box<dyn Plugin>) -> Self {
         plugin.setup(self) 
     }
+
+    pub fn with_subcontext<S: Subcontext>(self, subcontext: S) -> Self {
+        self
+    }
 }
 
 impl Default for EngineBuilder {

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -156,7 +156,8 @@ impl EngineBuilder {
         plugin.setup(self) 
     }
 
-    pub fn with_subcontext<S: Subcontext>(self, subcontext: S) -> Self {
+    pub fn with_subcontext<S: Subcontext>(mut self, subcontext: S) -> Self {
+        self.context.add(subcontext).unwrap();
         self
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -2,6 +2,7 @@ use std::mem::replace;
 
 use crate::contexts::EventContext;
 use crate::event::Event;
+use crate::plugins::CorePlugin;
 use crate::schedulers::FixedUpdateScheduler;
 use crate::*;
 
@@ -168,7 +169,7 @@ impl Default for EngineBuilder {
             context: Context::empty(),
             scheduler: Box::from(FixedUpdateScheduler::default()),
             core: Box::from(run_while_has_active_state),
-        }.with_plugin(CorePlugin::new())
+        }.with_plugin(Box::from(CorePlugin))
     }
 }
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -194,7 +194,7 @@ mod engine_builder_tests {
 
     use lazy_static::lazy_static;
 
-    use crate::contexts::SchedulerContext;
+    use crate::{contexts::{SchedulerContext, EventContext}, event::Event};
 
     use super::*;
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -253,5 +253,9 @@ mod engine_builder_tests {
         plugin.expect_setup()
             .times(1)
             .returning(|_| ());
+        
+        let _engine = EngineBuilder::new()
+            .with_plugin()
+            .build();
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -86,14 +86,9 @@ impl Engine {
     /// Takes ownership over the engine and runs until the [CoreFunction] exits.
     pub fn run(mut self, initial_state: Box<dyn State>) {
         log_startup_information();
-        self.add_required_subcontexts();
         self.state_stack.push(initial_state, &mut self.context);
         let (engine, core_function) = self.extract_core_function();
         (core_function)(engine);
-    }
-
-    fn add_required_subcontexts(&mut self) {
-        self.context.add(EventContext::<Event>::default()).unwrap();
     }
 
     fn extract_core_function(mut self) -> (Engine, Box<dyn Fn(Engine)>) {

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -256,7 +256,7 @@ mod engine_builder_tests {
         let mut plugin = MockPlugin::new();
         plugin.expect_setup()
             .times(1)
-            .returning(|_| ());
+            .returning(|engine_builder| engine_builder);
         
         let _engine = EngineBuilder::new()
             .with_plugin(Box::from(plugin))

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -147,7 +147,7 @@ impl EngineBuilder {
     }
 
     pub fn with_plugin(self, mut plugin: Box<dyn Plugin>) -> Self {
-        plugin.setup(self) 
+        plugin.setup(self)
     }
 
     pub fn with_subcontext<S: Subcontext>(mut self, subcontext: S) -> Self {
@@ -158,11 +158,12 @@ impl EngineBuilder {
 
 impl Default for EngineBuilder {
     fn default() -> Self {
-         Self {
+        Self {
             context: Context::empty(),
             scheduler: Box::from(FixedUpdateScheduler::default()),
             core: Box::from(run_while_has_active_state),
-        }.with_plugin(Box::from(CorePlugin))
+        }
+        .with_plugin(Box::from(CorePlugin))
     }
 }
 
@@ -194,7 +195,10 @@ mod engine_builder_tests {
 
     use lazy_static::lazy_static;
 
-    use crate::{contexts::{SchedulerContext, EventContext}, event::Event};
+    use crate::{
+        contexts::{EventContext, SchedulerContext},
+        event::Event,
+    };
 
     use super::*;
 
@@ -255,13 +259,12 @@ mod engine_builder_tests {
     #[test]
     fn should_load_plugins() {
         let mut plugin = MockPlugin::new();
-        plugin.expect_setup()
+        plugin
+            .expect_setup()
             .times(1)
             .returning(|engine_builder| engine_builder);
-        
-        let _engine = EngineBuilder::new()
-            .with_plugin(Box::from(plugin))
-            .build();
+
+        let _engine = EngineBuilder::new().with_plugin(Box::from(plugin)).build();
     }
 
     #[test]
@@ -271,7 +274,7 @@ mod engine_builder_tests {
         let starting_subcontexts = engine_builder.context.len();
 
         engine_builder = engine_builder.with_subcontext(subcontext);
-        
+
         let ending_subcontexts = engine_builder.context.len();
         let subcontexts_added = ending_subcontexts - starting_subcontexts;
         assert_eq!(subcontexts_added, 1, "The subcontext was not added");
@@ -281,9 +284,13 @@ mod engine_builder_tests {
     fn should_load_core_plugin() {
         let engine_builder = EngineBuilder::new();
 
-        let _event_context = engine_builder.context.get::<EventContext<Event>>()
+        let _event_context = engine_builder
+            .context
+            .get::<EventContext<Event>>()
             .expect("failed to get EventContext<Event>");
-        let _scheduler_context = engine_builder.context.get::<SchedulerContext>()
+        let _scheduler_context = engine_builder
+            .context
+            .get::<SchedulerContext>()
             .expect("failed to get SchedulerContext");
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -111,7 +111,6 @@ impl Engine {
 
 impl Default for Engine {
     fn default() -> Self {
-        let context = Context::default();
         EngineBuilder::new().build()
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -246,4 +246,9 @@ mod engine_builder_tests {
 
         fn render(&mut self, _context: &mut Context) -> RenderResult {}
     }
+
+    #[test]
+    fn should_load_plugins() {
+        let plugin = MockPlugin::new();
+    }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -200,6 +200,8 @@ mod engine_builder_tests {
 
     use lazy_static::lazy_static;
 
+    use crate::contexts::SchedulerContext;
+
     use super::*;
 
     #[test]
@@ -276,5 +278,15 @@ mod engine_builder_tests {
         engine_builder = engine_builder.with_subcontext(subcontext);
 
         assert_eq!(engine_builder.context.len(), 1, "The subcontext was not added");
+    }
+
+    #[test]
+    fn should_load_core_plugin() {
+        let engine_builder = EngineBuilder::new();
+
+        let _event_context = engine_builder.context.get::<EventContext<Event>>()
+            .expect("failed to get EventContext<Event>");
+        let _scheduler_context = engine_builder.context.get::<SchedulerContext>()
+            .expect("failed to get SchedulerContext");
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -262,4 +262,14 @@ mod engine_builder_tests {
             .with_plugin(Box::from(plugin))
             .build();
     }
+
+    #[test]
+    fn should_add_subcontexts_to_the_context_object() {
+        let engine_builder = EngineBuilder::new();
+        let subcontext = MockSubcontext::new();
+
+        engine_builder.with_subcontext(subcontext);
+
+        assert_eq!(engine_builder.context.subcontexts.len(), 1, "The subcontext was not added");
+    }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -274,6 +274,6 @@ mod engine_builder_tests {
 
         engine_builder.with_subcontext(subcontext);
 
-        assert_eq!(engine_builder.context.subcontexts.len(), 1, "The subcontext was not added");
+        assert_eq!(engine_builder.context.len(), 1, "The subcontext was not added");
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -249,6 +249,9 @@ mod engine_builder_tests {
 
     #[test]
     fn should_load_plugins() {
-        let plugin = MockPlugin::new();
+        let mut plugin = MockPlugin::new();
+        plugin.expect_setup()
+            .times(1)
+            .returning(|_| ());
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -129,7 +129,7 @@ impl EngineBuilder {
     }
 
     /// Consumes the engine builder and returns an [Engine] created from it.
-    pub fn build(self, context: Context) -> Engine {
+    pub fn build(self) -> Engine {
         Engine {
             context,
             scheduler: self.scheduler,

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -155,7 +155,7 @@ impl EngineBuilder {
 impl Default for EngineBuilder {
     fn default() -> Self {
         Self {
-            context: Context::default(),
+            context: Context::empty(),
             scheduler: Box::from(FixedUpdateScheduler::default()),
             core: Box::from(run_while_has_active_state),
         }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -35,13 +35,12 @@ use crate::*;
 /// can be used to customize just about every aspect of the engine.
 ///
 /// ```
-/// # use wolf_engine::{Engine, Context, EngineBuilder};
+/// # use wolf_engine::EngineBuilder;
 /// #
-/// let context = Context::default();
 /// // Add to the Context object here.
 /// let engine = EngineBuilder::new()
 ///     // Customize the engine here.
-///     .build(context);
+///     .build();
 /// ```
 ///
 /// You can refer to the [EngineBuilder], and [Context] documentation for specifics on

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -259,7 +259,7 @@ mod engine_builder_tests {
             .returning(|_| ());
         
         let _engine = EngineBuilder::new()
-            .with_plugin(plugin)
+            .with_plugin(Box::from(plugin))
             .build();
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -151,6 +151,10 @@ impl EngineBuilder {
         self.core = engine_core;
         self
     }
+
+    pub fn with_plugin(self, plugin: Box<dyn Plugin>) -> Self {
+        self
+    }
 }
 
 impl Default for EngineBuilder {

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -153,7 +153,7 @@ impl EngineBuilder {
     }
 
     pub fn with_plugin(self, plugin: Box<dyn Plugin>) -> Self {
-        self
+        plugin.setup(self) 
     }
 }
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -194,7 +194,6 @@ mod engine_builder_tests {
 
     #[test]
     fn should_allow_custom_states() {
-        let context = Context::default();
         let mut scheduler = MockScheduler::new();
         scheduler
             .expect_update()
@@ -206,7 +205,7 @@ mod engine_builder_tests {
 
         EngineBuilder::new()
             .with_scheduler(Box::from(scheduler))
-            .build(context)
+            .build()
             .run(Box::from(EmptyState));
     }
 
@@ -215,12 +214,11 @@ mod engine_builder_tests {
         lazy_static! {
             static ref HAS_RAN_CUSTOM_CORE: Mutex<bool> = Mutex::from(false);
         }
-        let context = Context::default();
         let engine = EngineBuilder::new()
             .with_engine_core(Box::from(|_| {
                 *HAS_RAN_CUSTOM_CORE.lock().unwrap() = true;
             }))
-            .build(context);
+            .build();
 
         engine.run(Box::from(EmptyState));
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -164,11 +164,11 @@ impl EngineBuilder {
 
 impl Default for EngineBuilder {
     fn default() -> Self {
-        Self {
+         Self {
             context: Context::empty(),
             scheduler: Box::from(FixedUpdateScheduler::default()),
             core: Box::from(run_while_has_active_state),
-        }
+        }.with_plugin(CorePlugin::new())
     }
 }
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -152,7 +152,7 @@ impl EngineBuilder {
         self
     }
 
-    pub fn with_plugin(self, plugin: Box<dyn Plugin>) -> Self {
+    pub fn with_plugin(self, mut plugin: Box<dyn Plugin>) -> Self {
         plugin.setup(self) 
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -269,10 +269,10 @@ mod engine_builder_tests {
 
     #[test]
     fn should_add_subcontexts_to_the_context_object() {
-        let engine_builder = EngineBuilder::new();
+        let mut engine_builder = EngineBuilder::new();
         let subcontext = MockSubcontext::new();
 
-        engine_builder.with_subcontext(subcontext);
+        engine_builder = engine_builder.with_subcontext(subcontext);
 
         assert_eq!(engine_builder.context.len(), 1, "The subcontext was not added");
     }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1,7 +1,5 @@
 use std::mem::replace;
 
-use crate::contexts::EventContext;
-use crate::event::Event;
 use crate::plugins::CorePlugin;
 use crate::schedulers::FixedUpdateScheduler;
 use crate::*;

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -119,7 +119,7 @@ impl Default for Engine {
 
 /// Build and customize an instance of the [Engine].
 pub struct EngineBuilder {
-    context: Context,
+    pub context: Context,
     scheduler: Box<dyn Scheduler>,
     core: CoreFunction,
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -270,10 +270,13 @@ mod engine_builder_tests {
     fn should_add_subcontexts_to_the_context_object() {
         let mut engine_builder = EngineBuilder::new();
         let subcontext = MockSubcontext::new();
+        let starting_subcontexts = engine_builder.context.len();
 
         engine_builder = engine_builder.with_subcontext(subcontext);
-
-        assert_eq!(engine_builder.context.len(), 1, "The subcontext was not added");
+        
+        let ending_subcontexts = engine_builder.context.len();
+        let subcontexts_added = ending_subcontexts - starting_subcontexts;
+        assert_eq!(subcontexts_added, 1, "The subcontext was not added");
     }
 
     #[test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,9 +3,11 @@ mod core_function;
 mod engine;
 mod scheduler;
 mod state;
+mod plugin;
 
 pub use context::*;
 pub use core_function::*;
 pub use engine::*;
 pub use scheduler::*;
 pub use state::*;
+pub use plugin::*;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,13 +1,13 @@
 mod context;
 mod core_function;
 mod engine;
+mod plugin;
 mod scheduler;
 mod state;
-mod plugin;
 
 pub use context::*;
 pub use core_function::*;
 pub use engine::*;
+pub use plugin::*;
 pub use scheduler::*;
 pub use state::*;
-pub use plugin::*;

--- a/src/core/plugin.rs
+++ b/src/core/plugin.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+use mockall::automock;
+
+#[cfg_attr(test, automock)]
+pub trait Plugin {}
+

--- a/src/core/plugin.rs
+++ b/src/core/plugin.rs
@@ -3,6 +3,54 @@ use mockall::automock;
 
 use crate::EngineBuilder;
 
+/// A plugin for the [EngineBuilder].
+///
+/// Plugins are loaded at startup and are given ownership over the [EngineBuilder].  
+/// From there, they are free to set things up however they need to.  
+///
+/// Plugins can: 
+///
+/// - Add `Subcontext`s to the main `Context`.
+/// - Remove `Subcontext`s from the main `Context`.
+/// - Add other `Plugins`.
+/// - Change the engine's `Scheduler`.
+/// - Change the engine's `CoreFunction` (
+/// - And anything else.
+///
+/// # Examples
+///
+/// Plugins are loaded with [EngineBuilder::with_plugin()].
+///
+/// ```
+/// # use wolf_engine::*;
+/// #
+/// # pub struct MyPlugin;
+/// #
+/// # impl Plugin for MyPlugin {
+/// #     fn setup(&mut self, engine_builder: EngineBuilder) -> EngineBuilder {
+/// #         engine_builder
+/// #     }
+/// # }
+/// ```
+///
+/// ## Creating a Custom Plugin
+///
+/// You can create a custom plugin by implementing this trait.
+///
+/// ```
+/// # use wolf_engine::*;
+/// #
+/// pub struct MyPlugin;
+///
+/// impl Plugin for MyPlugin {
+///     fn setup(&mut self, engine_builder: EngineBuilder) -> EngineBuilder {
+///         // Setup logic here.
+///         engine_builder
+///     }
+/// }
+/// ```
+///
+/// Ownership over the [EngineBuilder] must be returned back to the caller.
 #[cfg_attr(test, automock)]
 pub trait Plugin {
     fn setup(&mut self, engine_builder: EngineBuilder) -> EngineBuilder;

--- a/src/core/plugin.rs
+++ b/src/core/plugin.rs
@@ -1,6 +1,10 @@
 #[cfg(test)]
 use mockall::automock;
 
+use crate::EngineBuilder;
+
 #[cfg_attr(test, automock)]
-pub trait Plugin {}
+pub trait Plugin {
+    fn setup(&mut self, engine_builder: EngineBuilder);
+}
 

--- a/src/core/plugin.rs
+++ b/src/core/plugin.rs
@@ -6,17 +6,17 @@ use crate::EngineBuilder;
 /// Provides additional functionality to the engine.
 ///
 /// Plugins make it easy to extend the engine with new functionality.  Plugins are loaded
-/// at startup by the [EngineBuilder].  Plugins are given direct access to the 
-/// [EngineBuilder] during startup, and can add to it, or configure it in any way they 
+/// at startup by the [EngineBuilder].  Plugins are given direct access to the
+/// [EngineBuilder] during startup, and can add to it, or configure it in any way they
 /// need.
 ///
-/// Among other things, most plugins will: 
+/// Among other things, most plugins will:
 ///
 /// - Add `Subcontext`s to the main `Context`.
 /// - Remove `Subcontext`s from the main `Context`.
 /// - Add other `Plugins`.
 /// - Change the engine's `Scheduler`.
-/// - Change the engine's `CoreFunction`. 
+/// - Change the engine's `CoreFunction`.
 ///
 /// # Examples
 ///
@@ -40,7 +40,7 @@ use crate::EngineBuilder;
 /// ## Creating a Custom Plugin
 ///
 /// You can create a custom plugin by implementing this trait.
-/// 
+///
 /// ```
 /// # use wolf_engine::*;
 /// #

--- a/src/core/plugin.rs
+++ b/src/core/plugin.rs
@@ -3,19 +3,20 @@ use mockall::automock;
 
 use crate::EngineBuilder;
 
-/// A plugin for the [EngineBuilder].
+/// Provides additional functionality to the engine.
 ///
-/// Plugins are loaded at startup and are given ownership over the [EngineBuilder].  
-/// From there, they are free to set things up however they need to.  
+/// Plugins make it easy to extend the engine with new functionality.  Plugins are loaded
+/// at startup by the [EngineBuilder].  Plugins are given direct access to the 
+/// [EngineBuilder] during startup, and can add to it, or configure it in any way they 
+/// need.
 ///
-/// Plugins can: 
+/// Among other things, most plugins will: 
 ///
 /// - Add `Subcontext`s to the main `Context`.
 /// - Remove `Subcontext`s from the main `Context`.
 /// - Add other `Plugins`.
 /// - Change the engine's `Scheduler`.
-/// - Change the engine's `CoreFunction` (
-/// - And anything else.
+/// - Change the engine's `CoreFunction`. 
 ///
 /// # Examples
 ///
@@ -36,7 +37,7 @@ use crate::EngineBuilder;
 /// ## Creating a Custom Plugin
 ///
 /// You can create a custom plugin by implementing this trait.
-///
+/// 
 /// ```
 /// # use wolf_engine::*;
 /// #

--- a/src/core/plugin.rs
+++ b/src/core/plugin.rs
@@ -7,4 +7,3 @@ use crate::EngineBuilder;
 pub trait Plugin {
     fn setup(&mut self, engine_builder: EngineBuilder) -> EngineBuilder;
 }
-

--- a/src/core/plugin.rs
+++ b/src/core/plugin.rs
@@ -5,6 +5,6 @@ use crate::EngineBuilder;
 
 #[cfg_attr(test, automock)]
 pub trait Plugin {
-    fn setup(&mut self, engine_builder: EngineBuilder);
+    fn setup(&mut self, engine_builder: EngineBuilder) -> EngineBuilder;
 }
 

--- a/src/core/plugin.rs
+++ b/src/core/plugin.rs
@@ -32,6 +32,9 @@ use crate::EngineBuilder;
 /// #         engine_builder
 /// #     }
 /// # }
+/// #
+/// EngineBuilder::new()
+///     .with_plugin(Box::from(MyPlugin));
 /// ```
 ///
 /// ## Creating a Custom Plugin

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -70,7 +70,7 @@ pub type Frames = u64;
 ///
 /// ```
 /// # use wolf_engine::*;
-/// # use wolf_engine::schedulers::FixedUpdateSchedulerBuilder
+/// # use wolf_engine::schedulers::FixedUpdateSchedulerBuilder;
 /// #
 /// # // Using fixed game loop for the example because the actual loop is unimportant.
 /// # // Any Scheduler can be provided here and it will work just the same.

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -69,11 +69,8 @@ pub type Frames = u64;
 /// the `EngineBuilder::with_scheduler()` method.
 ///
 /// ```
-/// # use wolf_engine::{
-/// #    Context, EngineBuilder, schedulers::FixedUpdateSchedulerBuilder
-/// # };
-/// #
-/// # let context = Context::default();
+/// # use wolf_engine::*;
+/// # use wolf_engine::schedulers::FixedUpdateSchedulerBuilder
 /// #
 /// # // Using fixed game loop for the example because the actual loop is unimportant.
 /// # // Any Scheduler can be provided here and it will work just the same.
@@ -82,7 +79,7 @@ pub type Frames = u64;
 /// #
 /// let engine = EngineBuilder::new()
 ///     .with_scheduler(Box::from(custom_scheduler))
-///     .build(context);
+///     .build();
 /// ```
 #[cfg_attr(test, automock)]
 pub trait Scheduler {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ mod core;
 pub mod contexts;
 pub mod event;
 pub mod schedulers;
+pub mod plugins;
 
 #[cfg(feature = "logging")]
 pub mod logging;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,8 @@ mod core;
 
 pub mod contexts;
 pub mod event;
-pub mod schedulers;
 pub mod plugins;
+pub mod schedulers;
 
 #[cfg(feature = "logging")]
 pub mod logging;

--- a/src/plugins/core_plugin.rs
+++ b/src/plugins/core_plugin.rs
@@ -2,6 +2,7 @@ use crate::contexts::{EventContext, SchedulerContext};
 use crate::event::Event;
 use crate::*;
 
+/// Provides core functionality that **must** be loaded in order for the engine to work.
 pub(crate) struct CorePlugin;
 
 impl Plugin for CorePlugin {

--- a/src/plugins/core_plugin.rs
+++ b/src/plugins/core_plugin.rs
@@ -1,0 +1,13 @@
+use crate::*;
+use crate::event::Event;
+use crate::contexts::{SchedulerContext, EventContext};
+
+pub(crate) struct CorePlugin; 
+
+impl Plugin for CorePlugin {
+    fn setup(&mut self, engine_builder: EngineBuilder) -> EngineBuilder {
+        engine_builder
+            .with_subcontext(SchedulerContext::new())
+            .with_subcontext(EventContext::<Event>::default())
+    }
+}

--- a/src/plugins/core_plugin.rs
+++ b/src/plugins/core_plugin.rs
@@ -1,8 +1,8 @@
-use crate::*;
+use crate::contexts::{EventContext, SchedulerContext};
 use crate::event::Event;
-use crate::contexts::{SchedulerContext, EventContext};
+use crate::*;
 
-pub(crate) struct CorePlugin; 
+pub(crate) struct CorePlugin;
 
 impl Plugin for CorePlugin {
     fn setup(&mut self, engine_builder: EngineBuilder) -> EngineBuilder {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,3 +1,5 @@
+//! Provides built-in [Plugin] implementations.
+
 mod core_plugin;
 
 pub(crate) use core_plugin::*;

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,6 +1,5 @@
 use crate::{EngineBuilder, Plugin};
 
-
 pub(crate) struct CorePlugin; 
 
 impl Plugin for CorePlugin {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,4 +1,3 @@
 mod core_plugin;
 
 pub(crate) use core_plugin::*;
-

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,0 +1,10 @@
+use crate::{EngineBuilder, Plugin};
+
+
+pub(crate) struct CorePlugin; 
+
+impl Plugin for CorePlugin {
+    fn setup(&mut self, engine_builder: EngineBuilder) -> EngineBuilder {
+        engine_builder
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,11 +1,4 @@
-use crate::{EngineBuilder, Plugin, contexts::{SchedulerContext, EventContext}, event::Event};
+mod core_plugin;
 
-pub(crate) struct CorePlugin; 
+pub(crate) use core_plugin::*;
 
-impl Plugin for CorePlugin {
-    fn setup(&mut self, engine_builder: EngineBuilder) -> EngineBuilder {
-        engine_builder
-            .with_subcontext(SchedulerContext::new())
-            .with_subcontext(EventContext::<Event>::default())
-    }
-}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,4 +1,4 @@
-//! Provides built-in [Plugin] implementations.
+//! Provides built-in [Plugin](crate::Plugin) implementations.
 
 mod core_plugin;
 

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,9 +1,11 @@
-use crate::{EngineBuilder, Plugin};
+use crate::{EngineBuilder, Plugin, contexts::{SchedulerContext, EventContext}, event::Event};
 
 pub(crate) struct CorePlugin; 
 
 impl Plugin for CorePlugin {
     fn setup(&mut self, engine_builder: EngineBuilder) -> EngineBuilder {
         engine_builder
+            .with_subcontext(SchedulerContext::new())
+            .with_subcontext(EventContext::<Event>::default())
     }
 }

--- a/src/schedulers/fixed_update_scheduler.rs
+++ b/src/schedulers/fixed_update_scheduler.rs
@@ -374,7 +374,8 @@ mod fixed_update_scheduler_tests {
         let mut scheduler = FixedUpdateSchedulerBuilder::new().build();
         scheduler.lag = Duration::from_millis(artificial_lag);
         scheduler.update_time = Duration::from_millis(artificial_update_time);
-        let context = Context::default();
+        let mut context = Context::default();
+        context.add(SchedulerContext::new()).unwrap();
         (scheduler, context)
     }
 }


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

This PR implements the plugin system described in #51.  It also make a few additional changes to help integrate everything smoothly.  This PR closes #51. 

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

<!-- Select one (Delete the rest): -->

- Minor

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Removed the need for users to manually create the `Context`.
  - [x] Updated `EngineBuilder` to automatically create the `Context` for itself. 
  - [x] Removed `Context` argument from `EngineBuilder::build()`.
  - [x] Updated test cases to use new setup process.
  - [x] Updated examples to use new setup process.
- [x] Added the `Plugin` trait.
  - [x] Added `Plugin::setup()`.
- [x] Added the plugin system to the `EngineBuilder`.
  - [x] Added `EngineBuilder::with_plugin()`.
  - [x] Added `EngineBuilder::with_subcontext()`.
  - [x] Added public `Context` field.
- [x] Updated the `Context` struct. 
  - [x] Added `Context::len()` method.  
  - [x] Removed default `Subcontext` objects from the `Context`.
    - [x] Added test to ensure the `Context` always starts empty.
    - [x] Updated `Context::default()` to return `Context::empty()`.
    - [x] Updated `Context::new()` to return `Context::empty()`.
- [x] Added `CorePlugin`.
  - [x] Updated `EngineBuilder` to always load the `CorePlugin` first thing upon creation.
  - [x] Moved loading of default `Subcontext`s to `CorePlugin`.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relavent examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch.
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
