### PR TITLE
Fix/subcontext borrow checker issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wolf_engine"
 description = "A game framework with a focus on flexibility and ease of use."
-version = "0.14.0"
+version = "0.15.0"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/custom_subcontexts.rs
+++ b/examples/custom_subcontexts.rs
@@ -41,7 +41,7 @@ impl State for MyState {
     }
 
     fn render(&mut self, context: &mut Context) -> RenderResult {
-        let custom_context = context.get::<CustomContext>().unwrap();
+        let custom_context = context.borrow::<CustomContext>().unwrap();
         info!("{}: {}", custom_context.message, custom_context.count);
     }
 }

--- a/examples/custom_subcontexts.rs
+++ b/examples/custom_subcontexts.rs
@@ -31,7 +31,7 @@ pub struct MyState;
 
 impl State for MyState {
     fn update(&mut self, context: &mut Context) -> OptionalTransition {
-        let custom_context = context.get_mut::<CustomContext>().unwrap();
+        let mut custom_context = context.get_mut::<CustomContext>().unwrap();
         if custom_context.count == 10 {
             Some(Transition::Quit)
         } else {

--- a/examples/custom_subcontexts.rs
+++ b/examples/custom_subcontexts.rs
@@ -31,7 +31,7 @@ pub struct MyState;
 
 impl State for MyState {
     fn update(&mut self, context: &mut Context) -> OptionalTransition {
-        let mut custom_context = context.get_mut::<CustomContext>().unwrap();
+        let mut custom_context = context.borrow_mut::<CustomContext>().unwrap();
         if custom_context.count == 10 {
             Some(Transition::Quit)
         } else {

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -3,6 +3,7 @@ use rc_event_queue::LendingIterator;
 use wolf_engine::contexts::EventContext;
 use wolf_engine::event::EventReader;
 use wolf_engine::*;
+use wolf_engine::utils::trust_cell::Ref;
 
 pub fn main() {
     #[cfg(feature = "logging")]
@@ -51,7 +52,7 @@ impl ExampleState {
         }
     }
 
-    pub fn get_event_context(context: &Context) -> &EventContext<usize> {
+    pub fn get_event_context(context: &Context) -> Ref<EventContext<usize>> {
         context
             .get::<EventContext<usize>>()
             .expect("the context has no EventContext<usize>")

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -54,7 +54,7 @@ impl ExampleState {
 
     pub fn get_event_context(context: &Context) -> Ref<EventContext<usize>> {
         context
-            .get::<EventContext<usize>>()
+            .borrow::<EventContext<usize>>()
             .expect("the context has no EventContext<usize>")
     }
 }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -2,8 +2,8 @@ use log::*;
 use rc_event_queue::LendingIterator;
 use wolf_engine::contexts::EventContext;
 use wolf_engine::event::EventReader;
-use wolf_engine::*;
 use wolf_engine::utils::trust_cell::Ref;
+use wolf_engine::*;
 
 pub fn main() {
     #[cfg(feature = "logging")]

--- a/examples/plugins.rs
+++ b/examples/plugins.rs
@@ -55,7 +55,7 @@ pub struct GameState;
 
 impl State for GameState {
     fn update(&mut self, context: &mut Context) -> OptionalTransition {
-        let message = context.get::<MessageContext>().unwrap();
+        let message = context.borrow::<MessageContext>().unwrap();
         info!("{}", message.message);
         Some(Transition::Quit)
     }

--- a/licenses/LICENSE-SHRED-MIT
+++ b/licenses/LICENSE-SHRED-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2017 Thomas Schaller
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -1,0 +1,15 @@
+# Credits
+
+Wolf Engine borrows code from the following projects:
+
+## Shred
+
+- Upstream: [Github](https://github.com/amethyst/shred)
+- Version: 0.12 ([commit](https://github.com/amethyst/shred/tree/805d17ecda7d40af07b96609accdf601f05eb758))
+- License: Apache 2.0 / MIT
+
+Files extracted from upstream source:
+
+- [src/cell.rs](https://github.com/amethyst/shred/blob/805d17ecda7d40af07b96609accdf601f05eb758/src/cell.rs)
+- [LICENSE-MIT](https://github.com/amethyst/shred/blob/805d17ecda7d40af07b96609accdf601f05eb758/LICENSE-MIT)
+

--- a/src/contexts/event_context.rs
+++ b/src/contexts/event_context.rs
@@ -81,7 +81,7 @@ use crate::{
 /// # use wolf_engine::contexts::EventContext;
 /// # use wolf_engine::event::Event;
 /// #
-/// # let mut context = Context::empty();
+/// # let mut context = Context::new();
 /// # context.add(EventContext::<Event>::default()).unwrap();
 /// #
 /// let event_context = context.borrow::<EventContext<Event>>().expect("no event context");

--- a/src/contexts/event_context.rs
+++ b/src/contexts/event_context.rs
@@ -84,7 +84,7 @@ use crate::{
 /// # let mut context = Context::empty();
 /// # context.add(EventContext::<Event>::default()).unwrap();
 /// #
-/// let event_context = context.get::<EventContext<Event>>().expect("no event context");
+/// let event_context = context.borrow::<EventContext<Event>>().expect("no event context");
 /// ```
 ///
 /// # Preventing Memory Leaks

--- a/src/contexts/scheduler_context.rs
+++ b/src/contexts/scheduler_context.rs
@@ -24,7 +24,7 @@ use crate::{Frames, Subcontext, Ticks};
 /// # use wolf_engine::contexts::*;
 /// #
 /// # let scheduler_context = SchedulerContext::new();
-/// # let mut context = Context::empty();
+/// # let mut context = Context::new();
 /// # context.add(scheduler_context);
 /// #
 /// let scheduler_context = context.borrow::<SchedulerContext>()

--- a/src/contexts/scheduler_context.rs
+++ b/src/contexts/scheduler_context.rs
@@ -27,7 +27,7 @@ use crate::{Frames, Subcontext, Ticks};
 /// # let mut context = Context::empty();
 /// # context.add(scheduler_context);
 /// #
-/// let scheduler_context = context.get::<SchedulerContext>()
+/// let scheduler_context = context.borrow::<SchedulerContext>()
 ///     .expect("no scheduler context");
 /// ```
 ///

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -183,6 +183,7 @@ impl Context {
         self.subcontexts.len()
     }
 
+    /// Returns true if there are no [Subcontext]s currently stored.
     pub fn is_empty(&self) -> bool {
         self.subcontexts.is_empty()
     }

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -76,7 +76,7 @@ pub trait Subcontext: 'static {}
 /// }
 ///
 /// // If you want a mutable reference:
-/// if let Some(my_subcontext_mut) = context.get_mut::<MySubcontext>() {
+/// if let Some(my_subcontext_mut) = context.borrow_mut::<MySubcontext>() {
 ///     // Do something with the Subcontext.
 /// };
 ///
@@ -126,7 +126,7 @@ impl Context {
     }
 
     /// Access a specific type of [Subcontext] mutably.
-    pub fn get_mut<T: Subcontext>(&self) -> Option<RefMut<T>> {
+    pub fn borrow_mut<T: Subcontext>(&self) -> Option<RefMut<T>> {
         if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
             Some(cell.borrow_mut())
         } else {
@@ -248,7 +248,7 @@ mod context_tests {
             .expect("failed to add subcontext");
 
         let mut message_context = context
-            .get_mut::<MessageContext>()
+            .borrow_mut::<MessageContext>()
             .expect("got None instead of the subcontext");
         message_context.message = "Goodbye, world!".to_string();
 
@@ -266,7 +266,7 @@ mod context_tests {
             .expect("failed to add subcontext");
 
         let message_context = context.borrow::<MessageContext>().unwrap();
-        let mut print_context = context.get_mut::<PrintContext>().unwrap();
+        let mut print_context = context.borrow_mut::<PrintContext>().unwrap();
 
         print_context.print(&message_context);
 

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -247,7 +247,7 @@ mod context_tests {
             .add(MessageContext::new("Hello, world!"))
             .expect("failed to add subcontext");
 
-        let message_context = context
+        let mut message_context = context
             .get_mut::<MessageContext>()
             .expect("got None instead of the subcontext");
         message_context.message = "Goodbye, world!".to_string();

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -73,15 +73,20 @@ pub trait Subcontext: 'static {}
 /// // If you want an immutable reference:
 /// if let Some(my_subcontext) = context.try_borrow::<MySubcontext>() {
 ///     // Do something with the Subcontext.
-///     assert!(my_subcontext.is_ok());
-/// }
+/// #   assert!(my_subcontext.is_ok());
+/// } 
+/// # else {
+/// #    panic!("No subcontext found");
+/// # };
 ///
 /// // If you want a mutable reference:
 /// if let Some(my_subcontext_mut) = context.try_borrow_mut::<MySubcontext>() {
 ///     // Do something with the Subcontext.
-///     assert!(my_subcontext_mut.is_ok());
-/// };
-///
+/// #   assert!(my_subcontext_mut.is_ok());
+/// }
+/// # else {
+/// #   panic!("No subcontext found");
+/// # };
 pub struct Context {
     subcontexts: AnyMap,
 }

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -87,6 +87,7 @@ pub trait Subcontext: 'static {}
 /// # else {
 /// #   panic!("No subcontext found");
 /// # };
+/// ```
 pub struct Context {
     subcontexts: AnyMap,
 }

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -141,7 +141,7 @@ impl Context {
     /// code depending on it to panic or otherwise fail.  As a general rule, avoid
     /// removing anything you didn't add yourself.
     pub fn remove<T: Subcontext>(&mut self) {
-        self.subcontexts.remove::<T>();
+        self.subcontexts.remove::<TrustCell<T>>();
     }
 
     pub fn len(&self) -> usize {

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -29,11 +29,8 @@ pub trait Subcontext: 'static {}
 
 /// Provides a dynamic storage container for global [Engine](crate::Engine) state.
 ///
-/// The context object essentially provides a dynamic container for [Subcontext] objects.
-/// [Subcontext]s store data used by the engine, engine modules, or the game.
-/// Specific [Subcontext]s can be dynamically added, and retrieved by type, at runtime,
-/// allowing for greatly improved flexibility, as any type implementing the [Subcontext]
-/// trait can be used.  An [AnyMap] is used to achieve this behavior.
+/// This allows for custom [Subcontext] data to be dynamically added, and safely accessed
+/// at run-time.  Context utilizes [AnyMap], and [TrustCell] to implement this behavior.
 ///
 /// # Examples
 ///

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -102,15 +102,11 @@ impl Context {
         }
     }
 
-    /// Add a [Subcontext] object.
+    /// Add a [Subcontext].
     ///
-    /// This function ensures that only a single instance of each [Subcontext] type may
-    /// be added.  For example: If you add an instance of `SubcontextA`, then later
-    /// attempt to add another instance of `SubcontextA`, this will result in an error.
-    ///
-    /// A result is returned to indicate if the [Subcontext] was successfully added.  An
-    /// [Ok] indicates the context was added, and an [Err] indicates there is already an
-    /// instance of the type added.
+    /// Only a single instance of a [Subcontext] type may be added.  If the [Subcontext] 
+    /// cannot be added because another object of the same type is already present, an 
+    /// [Err] is returned.
     #[allow(clippy::map_entry)]
     pub fn add<T: Subcontext>(&mut self, subcontext: T) -> Result<(), ContextAlreadyExistsError> {
         if self.subcontexts.contains::<TrustCell<T>>() {
@@ -168,12 +164,12 @@ impl Context {
             .map(|cell| cell.borrow_mut())
     }
 
-    /// Remove a specific type of [Subcontext].
+    /// Remove a [Subcontext].
     ///
-    /// You should avoid removing a [Subcontext] unless you're 100% sure no other parts
-    /// of the code are depending on it.  Removing a [Subcontext] will likely cause any
-    /// code depending on it to panic or otherwise fail.  As a general rule, avoid
-    /// removing anything you didn't add yourself.
+    /// Removing a [Subcontext] is very likely to result in panics or weird behavior from
+    /// code depending on it.  Only remove [Subcontext]s if you're absolutely sure they 
+    /// aren't going to be used again.  Even then, you should only remove types you put 
+    /// there yourself.
     pub fn remove<T: Subcontext>(&mut self) {
         self.subcontexts.remove::<TrustCell<T>>();
     }

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -58,8 +58,8 @@ pub trait Subcontext: 'static {}
 /// context.add(my_subcontext);
 /// ```
 ///
-/// The [Subcontext] can be accessed again using [Context::get()] or
-/// [Context::get_mut()].
+/// The [Subcontext] can be accessed again using [Context::try_borrow()] or
+/// [Context::try_borrow_mut()].
 ///
 /// ```
 /// # use wolf_engine::*;
@@ -123,6 +123,10 @@ impl Context {
         }
     }
 
+    /// Get an immutable reference to a stored [Subcontext].
+    ///
+    /// Absence of write accesses is checked at run-time. If access is not possible, an 
+    /// error is returned.
     pub fn try_borrow<T: Subcontext>(&self) -> Option<Result<Ref<T>, InvalidBorrow>> {
         if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
             Some(cell.try_borrow())
@@ -131,7 +135,14 @@ impl Context {
         }
     }
 
-    /// Access a specific type of [Subcontext] immutably.
+    /// Get an immutable reference to a stored [Subcontext].
+    ///
+    /// Absence of write accesses is checked at run-time.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if there is a mutable reference to the data already in 
+    /// use.
     pub fn borrow<T: Subcontext>(&self) -> Option<Ref<T>> {
         if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
             Some(cell.borrow())
@@ -140,6 +151,10 @@ impl Context {
         }
     }
     
+    /// Get a mutable reference to the inner data.
+    ///
+    /// Exclusive access is checked at run-time. If access is not possible, an
+    /// error is returned.
     pub fn try_borrow_mut<T: Subcontext>(&self) -> Option<Result<RefMut<T>, InvalidBorrow>> {
         if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
             Some(cell.try_borrow_mut())
@@ -147,8 +162,14 @@ impl Context {
             None
         }
     }
-
-    /// Access a specific type of [Subcontext] mutably.
+    
+    /// Get a mutable reference to a stored [Subcontext].
+    ///
+    /// Exclusive access is checked at run-time.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if there are any references to the data already in use.
     pub fn borrow_mut<T: Subcontext>(&self) -> Option<RefMut<T>> {
         if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
             Some(cell.borrow_mut())

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -79,7 +79,7 @@ pub trait Subcontext: 'static {}
 /// // If you want a mutable reference:
 /// if let Some(my_subcontext_mut) = context.try_borrow_mut::<MySubcontext>() {
 ///     // Do something with the Subcontext.
-///     assert!(my_subcontext.is_ok());
+///     assert!(my_subcontext_mut.is_ok());
 /// };
 ///
 pub struct Context {

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -78,7 +78,7 @@ pub trait Subcontext: 'static {}
 /// // If you want a mutable reference:
 /// if let Some(my_subcontext_mut) = context.get_mut::<MySubcontext>() {
 ///     // Do something with the Subcontext.
-/// }
+/// };
 ///
 pub struct Context {
     subcontexts: AnyMap,

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -71,12 +71,12 @@ pub trait Subcontext: 'static {}
 /// # context.add(subcontext);
 /// #
 /// // If you want an immutable reference:
-/// if let Some(my_subcontext) = context.borrow::<MySubcontext>() {
+/// if let Some(my_subcontext) = context.try_borrow::<MySubcontext>() {
 ///     // Do something with the Subcontext.
 /// }
 ///
 /// // If you want a mutable reference:
-/// if let Some(my_subcontext_mut) = context.borrow_mut::<MySubcontext>() {
+/// if let Some(my_subcontext_mut) = context.try_borrow_mut::<MySubcontext>() {
 ///     // Do something with the Subcontext.
 /// };
 ///

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -34,12 +34,12 @@ pub trait Subcontext: 'static {}
 ///
 /// # Examples
 ///
-/// To create the default context, use [Context::default()];
+/// To create a new context, use [Context::new()];
 ///
 /// ```
 /// # use wolf_engine::Context;
 /// #
-/// let context = Context::default();
+/// let context = Context::new();
 /// ```
 ///
 /// Adding a [Subcontext] is done using the [Context::add()] method.

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -129,11 +129,7 @@ impl Context {
     /// Absence of write accesses is checked at run-time. If access is not possible, an
     /// error is returned.
     pub fn try_borrow<T: Subcontext>(&self) -> Option<Result<Ref<T>, InvalidBorrow>> {
-        if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
-            Some(cell.try_borrow())
-        } else {
-            None
-        }
+        self.subcontexts.get::<TrustCell<T>>().map(|cell| cell.try_borrow())
     }
 
     /// Get an immutable reference to a stored [Subcontext].
@@ -145,11 +141,7 @@ impl Context {
     /// This function will panic if there is a mutable reference to the data already in
     /// use.
     pub fn borrow<T: Subcontext>(&self) -> Option<Ref<T>> {
-        if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
-            Some(cell.borrow())
-        } else {
-            None
-        }
+        self.subcontexts.get::<TrustCell<T>>().map(|cell| cell.borrow())
     }
 
     /// Get a mutable reference to the inner data.
@@ -157,11 +149,7 @@ impl Context {
     /// Exclusive access is checked at run-time. If access is not possible, an
     /// error is returned.
     pub fn try_borrow_mut<T: Subcontext>(&self) -> Option<Result<RefMut<T>, InvalidBorrow>> {
-        if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
-            Some(cell.try_borrow_mut())
-        } else {
-            None
-        }
+        self.subcontexts.get::<TrustCell<T>>().map(|cell| cell.try_borrow_mut())
     }
 
     /// Get a mutable reference to a stored [Subcontext].
@@ -172,11 +160,7 @@ impl Context {
     ///
     /// This function will panic if there are any references to the data already in use.
     pub fn borrow_mut<T: Subcontext>(&self) -> Option<RefMut<T>> {
-        if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
-            Some(cell.borrow_mut())
-        } else {
-            None
-        }
+        self.subcontexts.get::<TrustCell<T>>().map(|cell| cell.borrow_mut())
     }
 
     /// Remove a specific type of [Subcontext].

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -177,7 +177,8 @@ impl Context {
     pub fn remove<T: Subcontext>(&mut self) {
         self.subcontexts.remove::<TrustCell<T>>();
     }
-
+    
+    /// Get the number of [Subcontext] currently stored.
     pub fn len(&self) -> usize {
         self.subcontexts.len()
     }

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -4,6 +4,8 @@ use std::fmt::{self, Display, Formatter};
 
 use anymap::AnyMap;
 
+use crate::utils::trust_cell::*;
+
 #[cfg(test)]
 use mockall::automock;
 
@@ -120,9 +122,13 @@ impl Context {
     }
 
     /// Access a specific type of [Subcontext] mutably.
-    pub fn get_mut<T: Subcontext>(&mut self) -> Option<&mut T> {
-        self.subcontexts.get_mut::<T>()
-    }
+    pub fn get_mut<T: Subcontext>(&self) -> Option<RefMut<T>> {
+        if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
+            Some(cell.borrow_mut())
+        } else {
+            None
+        }
+    } 
 
     /// Remove a specific type of [Subcontext].
     ///

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -124,7 +124,11 @@ impl Context {
     }
 
     pub fn try_borrow<T: Subcontext>(&self) -> Option<Result<Ref<T>, InvalidBorrow>> {
-        None
+        if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
+            Some(cell.try_borrow())
+        } else {
+            None
+        }
     }
 
     /// Access a specific type of [Subcontext] immutably.

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -27,7 +27,7 @@ impl Display for ContextAlreadyExistsError {
 #[cfg_attr(test, automock)]
 pub trait Subcontext: 'static {}
 
-///Provides a dynamic storage container for global [Engine](crate::Engine) state.
+/// Provides a dynamic storage container for global [Engine](crate::Engine) state.
 ///
 /// The context object essentially provides a dynamic container for [Subcontext] objects.
 /// [Subcontext]s store data used by the engine, engine modules, or the game.

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -73,11 +73,13 @@ pub trait Subcontext: 'static {}
 /// // If you want an immutable reference:
 /// if let Some(my_subcontext) = context.try_borrow::<MySubcontext>() {
 ///     // Do something with the Subcontext.
+///     assert!(my_subcontext.is_ok());
 /// }
 ///
 /// // If you want a mutable reference:
 /// if let Some(my_subcontext_mut) = context.try_borrow_mut::<MySubcontext>() {
 ///     // Do something with the Subcontext.
+///     assert!(my_subcontext.is_ok());
 /// };
 ///
 pub struct Context {

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -99,8 +99,8 @@ impl Context {
 
     /// Add a [Subcontext].
     ///
-    /// Only a single instance of a [Subcontext] type may be added.  If the [Subcontext] 
-    /// cannot be added because another object of the same type is already present, an 
+    /// Only a single instance of a [Subcontext] type may be added.  If the [Subcontext]
+    /// cannot be added because another object of the same type is already present, an
     /// [Err] is returned.
     #[allow(clippy::map_entry)]
     pub fn add<T: Subcontext>(&mut self, subcontext: T) -> Result<(), ContextAlreadyExistsError> {
@@ -162,13 +162,13 @@ impl Context {
     /// Remove a [Subcontext].
     ///
     /// Removing a [Subcontext] is very likely to result in panics or weird behavior from
-    /// code depending on it.  Only remove [Subcontext]s if you're absolutely sure they 
-    /// aren't going to be used again.  Even then, you should only remove types you put 
+    /// code depending on it.  Only remove [Subcontext]s if you're absolutely sure they
+    /// aren't going to be used again.  Even then, you should only remove types you put
     /// there yourself.
     pub fn remove<T: Subcontext>(&mut self) {
         self.subcontexts.remove::<TrustCell<T>>();
     }
-    
+
     /// Get the number of [Subcontext] currently stored.
     pub fn len(&self) -> usize {
         self.subcontexts.len()

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -50,7 +50,7 @@ pub trait Subcontext: 'static {}
 /// # struct MySubcontext;
 /// # impl Subcontext for MySubcontext {}
 /// # let my_subcontext = MySubcontext;
-/// # let mut context = Context::empty();
+/// # let mut context = Context::new();
 /// #
 /// context.add(my_subcontext);
 /// ```
@@ -64,7 +64,7 @@ pub trait Subcontext: 'static {}
 /// # struct MySubcontext;
 /// # impl Subcontext for MySubcontext {}
 /// # let subcontext = MySubcontext;
-/// # let mut context = Context::empty();
+/// # let mut context = Context::new();
 /// # context.add(subcontext);
 /// #
 /// // If you want an immutable reference:
@@ -92,11 +92,6 @@ pub struct Context {
 impl Context {
     /// Create a new context with no [Subcontext]s.
     pub fn new() -> Self {
-        Self::empty()
-    }
-
-    /// Create an empty context with no [Subcontext]s.
-    pub fn empty() -> Self {
         Self {
             subcontexts: AnyMap::new(),
         }
@@ -201,10 +196,6 @@ mod context_tests {
     fn should_always_start_with_no_subcontexts() {
         assert!(Context::new().is_empty(), "Context::new() was not empty");
         assert!(
-            Context::empty().is_empty(),
-            "Context::empty() was not empty"
-        );
-        assert!(
             Context::default().is_empty(),
             "Context::default() was not empty"
         );
@@ -212,7 +203,7 @@ mod context_tests {
 
     #[test]
     fn should_add_subcontext() {
-        let mut context = Context::empty();
+        let mut context = Context::new();
         let subcontext = MockSubcontext::new();
 
         context.add(subcontext).expect("failed to add subcontext");
@@ -222,7 +213,7 @@ mod context_tests {
 
     #[test]
     fn should_allow_only_one_subcontext_of_a_given_type() {
-        let mut context = Context::empty();
+        let mut context = Context::new();
         let subcontext_a = MockSubcontext::new();
         let subcontext_b = MockSubcontext::new();
 
@@ -238,7 +229,7 @@ mod context_tests {
 
     #[test]
     fn should_remove_subcontext() {
-        let mut context = Context::empty();
+        let mut context = Context::new();
         let subcontext = MockSubcontext::new();
         context.add(subcontext).expect("failed to add subcontext");
 
@@ -253,14 +244,14 @@ mod context_tests {
 
     #[test]
     fn should_fail_silently_if_removing_nonexistent_subcontext() {
-        let mut context = Context::empty();
+        let mut context = Context::new();
 
         context.remove::<MockSubcontext>();
     }
 
     #[test]
     fn should_provide_immutable_access_to_subcontexts() {
-        let mut context = Context::empty();
+        let mut context = Context::new();
         context
             .add(MessageContext::new("Hello, world!"))
             .expect("failed to add subcontext");
@@ -274,7 +265,7 @@ mod context_tests {
 
     #[test]
     fn should_provide_mutable_access_to_subcontexts() {
-        let mut context = Context::empty();
+        let mut context = Context::new();
         context
             .add(MessageContext::new("Hello, world!"))
             .expect("failed to add subcontext");
@@ -289,7 +280,7 @@ mod context_tests {
 
     #[test]
     fn should_not_fight_the_borrow_checker_on_access_to_subcontexts() {
-        let mut context = Context::empty();
+        let mut context = Context::new();
         context
             .add(MessageContext::new("Hello, world!"))
             .expect("failed to add subcontext");

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -71,7 +71,7 @@ pub trait Subcontext: 'static {}
 /// # context.add(subcontext);
 /// #
 /// // If you want an immutable reference:
-/// if let Some(my_subcontext) = context.get::<MySubcontext>() {
+/// if let Some(my_subcontext) = context.borrow::<MySubcontext>() {
 ///     // Do something with the Subcontext.
 /// }
 ///
@@ -117,7 +117,7 @@ impl Context {
     }
 
     /// Access a specific type of [Subcontext] immutably.
-    pub fn get<T: Subcontext>(&self) -> Option<Ref<T>> {
+    pub fn borrow<T: Subcontext>(&self) -> Option<Ref<T>> {
         if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
             Some(cell.borrow())
         } else {
@@ -234,7 +234,7 @@ mod context_tests {
             .expect("failed to add subcontext");
 
         let message_context = context
-            .get::<MessageContext>()
+            .borrow::<MessageContext>()
             .expect("got None instead of the subcontext");
 
         assert_eq!(message_context.message, "Hello, world!");
@@ -265,7 +265,7 @@ mod context_tests {
             .add(PrintContext::new())
             .expect("failed to add subcontext");
 
-        let message_context = context.get::<MessageContext>().unwrap();
+        let message_context = context.borrow::<MessageContext>().unwrap();
         let mut print_context = context.get_mut::<PrintContext>().unwrap();
 
         print_context.print(&message_context);

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -117,8 +117,12 @@ impl Context {
     }
 
     /// Access a specific type of [Subcontext] immutably.
-    pub fn get<T: Subcontext>(&self) -> Option<&T> {
-        self.subcontexts.get::<T>()
+    pub fn get<T: Subcontext>(&self) -> Option<Ref<T>> {
+        if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
+            Some(cell.borrow())
+        } else {
+            None
+        }
     }
 
     /// Access a specific type of [Subcontext] mutably.

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -116,6 +116,10 @@ impl Context {
         }
     }
 
+    pub fn try_borrow<T: Subcontext>(&self) -> Option<Result<Ref<T>, InvalidBorrow>> {
+        None
+    }
+
     /// Access a specific type of [Subcontext] immutably.
     pub fn borrow<T: Subcontext>(&self) -> Option<Ref<T>> {
         if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -129,7 +129,9 @@ impl Context {
     /// Absence of write accesses is checked at run-time. If access is not possible, an
     /// error is returned.
     pub fn try_borrow<T: Subcontext>(&self) -> Option<Result<Ref<T>, InvalidBorrow>> {
-        self.subcontexts.get::<TrustCell<T>>().map(|cell| cell.try_borrow())
+        self.subcontexts
+            .get::<TrustCell<T>>()
+            .map(|cell| cell.try_borrow())
     }
 
     /// Get an immutable reference to a stored [Subcontext].
@@ -141,7 +143,9 @@ impl Context {
     /// This function will panic if there is a mutable reference to the data already in
     /// use.
     pub fn borrow<T: Subcontext>(&self) -> Option<Ref<T>> {
-        self.subcontexts.get::<TrustCell<T>>().map(|cell| cell.borrow())
+        self.subcontexts
+            .get::<TrustCell<T>>()
+            .map(|cell| cell.borrow())
     }
 
     /// Get a mutable reference to the inner data.
@@ -149,7 +153,9 @@ impl Context {
     /// Exclusive access is checked at run-time. If access is not possible, an
     /// error is returned.
     pub fn try_borrow_mut<T: Subcontext>(&self) -> Option<Result<RefMut<T>, InvalidBorrow>> {
-        self.subcontexts.get::<TrustCell<T>>().map(|cell| cell.try_borrow_mut())
+        self.subcontexts
+            .get::<TrustCell<T>>()
+            .map(|cell| cell.try_borrow_mut())
     }
 
     /// Get a mutable reference to a stored [Subcontext].
@@ -160,7 +166,9 @@ impl Context {
     ///
     /// This function will panic if there are any references to the data already in use.
     pub fn borrow_mut<T: Subcontext>(&self) -> Option<RefMut<T>> {
-        self.subcontexts.get::<TrustCell<T>>().map(|cell| cell.borrow_mut())
+        self.subcontexts
+            .get::<TrustCell<T>>()
+            .map(|cell| cell.borrow_mut())
     }
 
     /// Remove a specific type of [Subcontext].

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -141,7 +141,11 @@ impl Context {
     }
     
     pub fn try_borrow_mut<T: Subcontext>(&self) -> Option<Result<RefMut<T>, InvalidBorrow>> {
-        None
+        if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
+            Some(cell.try_borrow_mut())
+        } else {
+            None
+        }
     }
 
     /// Access a specific type of [Subcontext] mutably.

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -108,10 +108,10 @@ impl Context {
     /// instance of the type added.
     #[allow(clippy::map_entry)]
     pub fn add<T: Subcontext>(&mut self, subcontext: T) -> Result<(), ContextAlreadyExistsError> {
-        if self.subcontexts.contains::<T>() {
+        if self.subcontexts.contains::<TrustCell<T>>() {
             Err(ContextAlreadyExistsError)
         } else {
-            self.subcontexts.insert(subcontext);
+            self.subcontexts.insert(TrustCell::new(subcontext));
             Ok(())
         }
     }

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -74,7 +74,7 @@ pub trait Subcontext: 'static {}
 /// if let Some(my_subcontext) = context.try_borrow::<MySubcontext>() {
 ///     // Do something with the Subcontext.
 /// #   assert!(my_subcontext.is_ok());
-/// } 
+/// }
 /// # else {
 /// #    panic!("No subcontext found");
 /// # };
@@ -126,7 +126,7 @@ impl Context {
 
     /// Get an immutable reference to a stored [Subcontext].
     ///
-    /// Absence of write accesses is checked at run-time. If access is not possible, an 
+    /// Absence of write accesses is checked at run-time. If access is not possible, an
     /// error is returned.
     pub fn try_borrow<T: Subcontext>(&self) -> Option<Result<Ref<T>, InvalidBorrow>> {
         if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
@@ -142,7 +142,7 @@ impl Context {
     ///
     /// # Panics
     ///
-    /// This function will panic if there is a mutable reference to the data already in 
+    /// This function will panic if there is a mutable reference to the data already in
     /// use.
     pub fn borrow<T: Subcontext>(&self) -> Option<Ref<T>> {
         if let Some(cell) = self.subcontexts.get::<TrustCell<T>>() {
@@ -151,7 +151,7 @@ impl Context {
             None
         }
     }
-    
+
     /// Get a mutable reference to the inner data.
     ///
     /// Exclusive access is checked at run-time. If access is not possible, an
@@ -163,7 +163,7 @@ impl Context {
             None
         }
     }
-    
+
     /// Get a mutable reference to a stored [Subcontext].
     ///
     /// Exclusive access is checked at run-time.
@@ -177,7 +177,7 @@ impl Context {
         } else {
             None
         }
-    } 
+    }
 
     /// Remove a specific type of [Subcontext].
     ///
@@ -326,9 +326,7 @@ mod context_tests {
 
     impl PrintContext {
         pub fn new() -> Self {
-            Self {
-                prints: 0,
-            }
+            Self { prints: 0 }
         }
 
         pub fn print(&mut self, message: &MessageContext) {
@@ -336,7 +334,6 @@ mod context_tests {
             self.prints += 1;
         }
     }
-
 
     struct MessageContext {
         pub message: String,

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -128,6 +128,10 @@ impl Context {
             None
         }
     }
+    
+    pub fn try_borrow_mut<T: Subcontext>(&self) -> Option<Result<RefMut<T>, InvalidBorrow>> {
+        None
+    }
 
     /// Access a specific type of [Subcontext] mutably.
     pub fn borrow_mut<T: Subcontext>(&self) -> Option<RefMut<T>> {

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -270,11 +270,11 @@ mod engine_builder_tests {
 
         let _event_context = engine
             .context
-            .get::<EventContext<Event>>()
+            .borrow::<EventContext<Event>>()
             .expect("failed to get EventContext<Event>");
         let _scheduler_context = engine
             .context
-            .get::<SchedulerContext>()
+            .borrow::<SchedulerContext>()
             .expect("failed to get SchedulerContext");
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -246,7 +246,7 @@ mod engine_builder_tests {
         plugin
             .expect_setup()
             .times(1)
-            .returning(|engine_builder| Ok(engine_builder));
+            .returning(Ok);
 
         let _engine = EngineBuilder::new().with_plugin(Box::from(plugin)).build();
     }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -243,10 +243,7 @@ mod engine_builder_tests {
     #[test]
     fn should_load_plugins() {
         let mut plugin = MockPlugin::new();
-        plugin
-            .expect_setup()
-            .times(1)
-            .returning(Ok);
+        plugin.expect_setup().times(1).returning(Ok);
 
         let _engine = EngineBuilder::new().with_plugin(Box::from(plugin)).build();
     }

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -100,7 +100,7 @@ mod plugin_loader_tests {
         plugin
             .expect_setup()
             .once()
-            .returning(|engine_builder| Ok(engine_builder));
+            .returning(Ok);
         plugin
     }
 

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -97,10 +97,7 @@ mod plugin_loader_tests {
 
     fn mock_plugin() -> MockPlugin {
         let mut plugin = MockPlugin::new();
-        plugin
-            .expect_setup()
-            .once()
-            .returning(Ok);
+        plugin.expect_setup().once().returning(Ok);
         plugin
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub mod contexts;
 pub mod event;
 pub mod plugins;
 pub mod schedulers;
+pub mod utils;
 
 #[cfg(feature = "logging")]
 pub mod logging;

--- a/src/schedulers/fixed_update_scheduler.rs
+++ b/src/schedulers/fixed_update_scheduler.rs
@@ -153,7 +153,7 @@ impl FixedUpdateScheduler {
     fn tick(&mut self, state: &mut dyn State, context: &mut Context) {
         let tick_run_time = Self::run_tick_and_track_execution_time(state, context);
         self.update_timing(tick_run_time);
-        if let Some(scheduler_context) = context.get_mut::<SchedulerContext>() {
+        if let Some(mut scheduler_context) = context.get_mut::<SchedulerContext>() {
             scheduler_context.add_tick();
         }
     }
@@ -174,7 +174,7 @@ impl Scheduler for FixedUpdateScheduler {
 
     fn render(&mut self, context: &mut Context, state: &mut dyn State) {
         state.render(context);
-        if let Some(scheduler_context) = context.get_mut::<SchedulerContext>() {
+        if let Some(mut scheduler_context) = context.get_mut::<SchedulerContext>() {
             scheduler_context.add_frame();
         }
     }

--- a/src/schedulers/fixed_update_scheduler.rs
+++ b/src/schedulers/fixed_update_scheduler.rs
@@ -153,7 +153,7 @@ impl FixedUpdateScheduler {
     fn tick(&mut self, state: &mut dyn State, context: &mut Context) {
         let tick_run_time = Self::run_tick_and_track_execution_time(state, context);
         self.update_timing(tick_run_time);
-        if let Some(mut scheduler_context) = context.get_mut::<SchedulerContext>() {
+        if let Some(mut scheduler_context) = context.borrow_mut::<SchedulerContext>() {
             scheduler_context.add_tick();
         }
     }
@@ -174,7 +174,7 @@ impl Scheduler for FixedUpdateScheduler {
 
     fn render(&mut self, context: &mut Context, state: &mut dyn State) {
         state.render(context);
-        if let Some(mut scheduler_context) = context.get_mut::<SchedulerContext>() {
+        if let Some(mut scheduler_context) = context.borrow_mut::<SchedulerContext>() {
             scheduler_context.add_frame();
         }
     }

--- a/src/schedulers/fixed_update_scheduler.rs
+++ b/src/schedulers/fixed_update_scheduler.rs
@@ -322,7 +322,7 @@ mod fixed_update_scheduler_tests {
         scheduler.update(&mut context, &mut state);
 
         let scheduler_context = context
-            .get::<SchedulerContext>()
+            .borrow::<SchedulerContext>()
             .expect("no SchedulerContext");
         assert!(
             scheduler_context.ticks() >= minimum_ticks,
@@ -341,7 +341,7 @@ mod fixed_update_scheduler_tests {
         }
 
         let scheduler_context = context
-            .get::<SchedulerContext>()
+            .borrow::<SchedulerContext>()
             .expect("no SchedulerContext");
         assert_eq!(
             scheduler_context.frames(),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,1 +1,3 @@
+//! Provides common helpers and utilities.
+
 pub mod trust_cell;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod trust_cell;

--- a/src/utils/trust_cell.rs
+++ b/src/utils/trust_cell.rs
@@ -1,4 +1,6 @@
-//! Helper module for some internals, most users don't need to interact with it.
+//! Provides a thread-safe [TrustCell]. 
+//!
+//! This code is borrowed from [Shred](https://github.com/amethyst/shred).
 
 use std::{
     cell::UnsafeCell,

--- a/src/utils/trust_cell.rs
+++ b/src/utils/trust_cell.rs
@@ -1,4 +1,4 @@
-//! Provides a thread-safe [TrustCell]. 
+//! Provides a thread-safe [TrustCell].
 //!
 //! This code is borrowed from [Shred](https://github.com/amethyst/shred).
 
@@ -622,4 +622,3 @@ mod tests {
         assert_eq!(cell.flag.load(Ordering::SeqCst), 0);
     }
 }
-

--- a/src/utils/trust_cell.rs
+++ b/src/utils/trust_cell.rs
@@ -1,0 +1,621 @@
+//! Helper module for some internals, most users don't need to interact with it.
+
+use std::{
+    cell::UnsafeCell,
+    error::Error,
+    fmt::{Display, Error as FormatError, Formatter},
+    ops::{Deref, DerefMut},
+    sync::atomic::{AtomicUsize, Ordering},
+    usize,
+};
+
+macro_rules! borrow_panic {
+    ($s:expr) => {{
+        panic!(
+            "Tried to fetch data of type {:?}, but it was already borrowed{}.",
+            ::std::any::type_name::<T>(),
+            $s,
+        )
+    }};
+}
+
+/// Marker struct for an invalid borrow error
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct InvalidBorrow;
+
+impl Display for InvalidBorrow {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FormatError> {
+        write!(f, "Tried to borrow when it was illegal")
+    }
+}
+
+impl Error for InvalidBorrow {
+    fn description(&self) -> &str {
+        "This error is returned when you try to borrow immutably when it's already \
+         borrowed mutably or you try to borrow mutably when it's already borrowed"
+    }
+}
+
+/// An immutable reference to data in a `TrustCell`.
+///
+/// Access the value via `std::ops::Deref` (e.g. `*val`)
+#[derive(Debug)]
+pub struct Ref<'a, T: ?Sized + 'a> {
+    flag: &'a AtomicUsize,
+    value: &'a T,
+}
+
+impl<'a, T: ?Sized> Ref<'a, T> {
+    /// Makes a new `Ref` for a component of the borrowed data which preserves
+    /// the existing borrow.
+    ///
+    /// The `TrustCell` is already immutably borrowed, so this cannot fail.
+    ///
+    /// This is an associated function that needs to be used as `Ref::map(...)`.
+    /// A method would interfere with methods of the same name on the contents
+    /// of a `Ref` used through `Deref`. Further this preserves the borrow of
+    /// the value and hence does the proper cleanup when it's dropped.
+    ///
+    /// # Examples
+    ///
+    /// This can be used to avoid pointer indirection when a boxed item is
+    /// stored in the `TrustCell`.
+    ///
+    /// ```
+    /// use shred::cell::{Ref, TrustCell};
+    ///
+    /// let cb = TrustCell::new(Box::new(5));
+    ///
+    /// // Borrowing the cell causes the `Ref` to store a reference to the `Box`, which is a
+    /// // pointer to the value on the heap, not the actual value.
+    /// let boxed_ref: Ref<'_, Box<usize>> = cb.borrow();
+    /// assert_eq!(**boxed_ref, 5); // Notice the double deref to get the actual value.
+    ///
+    /// // By using `map` we can let `Ref` store a reference directly to the value on the heap.
+    /// let pure_ref: Ref<'_, usize> = Ref::map(boxed_ref, Box::as_ref);
+    ///
+    /// assert_eq!(*pure_ref, 5);
+    /// ```
+    ///
+    /// We can also use `map` to get a reference to a sub-part of the borrowed
+    /// value.
+    ///
+    /// ```rust
+    /// # use shred::cell::{TrustCell, Ref};
+    ///
+    /// let c = TrustCell::new((5, 'b'));
+    /// let b1: Ref<'_, (u32, char)> = c.borrow();
+    /// let b2: Ref<'_, u32> = Ref::map(b1, |t| &t.0);
+    /// assert_eq!(*b2, 5);
+    /// ```
+    pub fn map<U, F>(self, f: F) -> Ref<'a, U>
+    where
+        F: FnOnce(&T) -> &U,
+        U: ?Sized,
+    {
+        // Extract the values from the `Ref` through a pointer so that we do not run
+        // `Drop`. Because the returned `Ref` has the same lifetime `'a` as the
+        // given `Ref`, the lifetime we created through turning the pointer into
+        // a ref is valid.
+        let flag = unsafe { &*(self.flag as *const _) };
+        let value = unsafe { &*(self.value as *const _) };
+
+        // We have to forget self so that we do not run `Drop`. Further it's safe
+        // because we are creating a new `Ref`, with the same flag, which will
+        // run the cleanup when it's dropped.
+        std::mem::forget(self);
+
+        Ref {
+            flag,
+            value: f(value),
+        }
+    }
+}
+
+impl<'a, T: ?Sized> Deref for Ref<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.value
+    }
+}
+
+impl<'a, T: ?Sized> Drop for Ref<'a, T> {
+    fn drop(&mut self) {
+        self.flag.fetch_sub(1, Ordering::Release);
+    }
+}
+
+impl<'a, T: ?Sized> Clone for Ref<'a, T> {
+    fn clone(&self) -> Self {
+        self.flag.fetch_add(1, Ordering::Release);
+        Ref {
+            flag: self.flag,
+            value: self.value,
+        }
+    }
+}
+
+/// A mutable reference to data in a `TrustCell`.
+///
+/// Access the value via `std::ops::DerefMut` (e.g. `*val`)
+#[derive(Debug)]
+pub struct RefMut<'a, T: ?Sized + 'a> {
+    flag: &'a AtomicUsize,
+    value: &'a mut T,
+}
+
+impl<'a, T: ?Sized> RefMut<'a, T> {
+    /// Makes a new `RefMut` for a component of the borrowed data which
+    /// preserves the existing borrow.
+    ///
+    /// The `TrustCell` is already mutably borrowed, so this cannot fail.
+    ///
+    /// This is an associated function that needs to be used as
+    /// `RefMut::map(...)`. A method would interfere with methods of the
+    /// same name on the contents of a `RefMut` used through `DerefMut`.
+    /// Further this preserves the borrow of the value and hence does the
+    /// proper cleanup when it's dropped.
+    ///
+    /// # Examples
+    ///
+    /// This can also be used to avoid pointer indirection when a boxed item is
+    /// stored in the `TrustCell`.
+    ///
+    /// ```
+    /// use shred::cell::{RefMut, TrustCell};
+    ///
+    /// let cb = TrustCell::new(Box::new(5));
+    ///
+    /// // Borrowing the cell causes the `RefMut` to store a reference to the `Box`, which is a
+    /// // pointer to the value on the heap, and not a reference directly to the value.
+    /// let boxed_ref: RefMut<'_, Box<usize>> = cb.borrow_mut();
+    /// assert_eq!(**boxed_ref, 5); // Notice the double deref to get the actual value.
+    ///
+    /// // By using `map` we can let `RefMut` store a reference directly to the value on the heap.
+    /// let pure_ref: RefMut<'_, usize> = RefMut::map(boxed_ref, Box::as_mut);
+    ///
+    /// assert_eq!(*pure_ref, 5);
+    /// ```
+    ///
+    /// We can also use `map` to get a reference to a sub-part of the borrowed
+    /// value.
+    ///
+    /// ```rust
+    /// # use shred::cell::{TrustCell, RefMut};
+    ///
+    /// let c = TrustCell::new((5, 'b'));
+    ///
+    /// let b1: RefMut<'_, (u32, char)> = c.borrow_mut();
+    /// let b2: RefMut<'_, u32> = RefMut::map(b1, |t| &mut t.0);
+    /// assert_eq!(*b2, 5);
+    /// ```
+    pub fn map<U, F>(self, f: F) -> RefMut<'a, U>
+    where
+        F: FnOnce(&mut T) -> &mut U,
+        U: ?Sized,
+    {
+        // Extract the values from the `RefMut` through a pointer so that we do not run
+        // `Drop`. Because the returned `RefMut` has the same lifetime `'a` as
+        // the given `RefMut`, the lifetime we created through turning the
+        // pointer into a ref is valid.
+        let flag = unsafe { &*(self.flag as *const _) };
+        let value = unsafe { &mut *(self.value as *mut _) };
+
+        // We have to forget self so that we do not run `Drop`. Further it's safe
+        // because we are creating a new `RefMut`, with the same flag, which
+        // will run the cleanup when it's dropped.
+        std::mem::forget(self);
+
+        RefMut {
+            flag,
+            value: f(value),
+        }
+    }
+}
+
+impl<'a, T: ?Sized> Deref for RefMut<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.value
+    }
+}
+
+impl<'a, T: ?Sized> DerefMut for RefMut<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.value
+    }
+}
+
+impl<'a, T: ?Sized> Drop for RefMut<'a, T> {
+    fn drop(&mut self) {
+        self.flag.store(0, Ordering::Release)
+    }
+}
+
+/// A custom cell container that is a `RefCell` with thread-safety.
+#[derive(Debug)]
+pub struct TrustCell<T> {
+    flag: AtomicUsize,
+    inner: UnsafeCell<T>,
+}
+
+impl<T> TrustCell<T> {
+    /// Create a new cell, similar to `RefCell::new`
+    pub fn new(val: T) -> Self {
+        TrustCell {
+            flag: AtomicUsize::new(0),
+            inner: UnsafeCell::new(val),
+        }
+    }
+
+    /// Consumes this cell and returns ownership of `T`.
+    pub fn into_inner(self) -> T {
+        self.inner.into_inner()
+    }
+
+    /// Get an immutable reference to the inner data.
+    ///
+    /// Absence of write accesses is checked at run-time.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if there is a mutable reference to the data
+    /// already in use.
+    pub fn borrow(&self) -> Ref<T> {
+        self.check_flag_read()
+            .unwrap_or_else(|_| borrow_panic!(" mutably"));
+
+        Ref {
+            flag: &self.flag,
+            value: unsafe { &*self.inner.get() },
+        }
+    }
+
+    /// Get an immutable reference to the inner data.
+    ///
+    /// Absence of write accesses is checked at run-time. If access is not
+    /// possible, an error is returned.
+    pub fn try_borrow(&self) -> Result<Ref<T>, InvalidBorrow> {
+        self.check_flag_read()?;
+
+        Ok(Ref {
+            flag: &self.flag,
+            value: unsafe { &*self.inner.get() },
+        })
+    }
+
+    /// Get a mutable reference to the inner data.
+    ///
+    /// Exclusive access is checked at run-time.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if there are any references to the data already
+    /// in use.
+    pub fn borrow_mut(&self) -> RefMut<T> {
+        self.check_flag_write()
+            .unwrap_or_else(|_| borrow_panic!(""));
+
+        RefMut {
+            flag: &self.flag,
+            value: unsafe { &mut *self.inner.get() },
+        }
+    }
+
+    /// Get a mutable reference to the inner data.
+    ///
+    /// Exclusive access is checked at run-time. If access is not possible, an
+    /// error is returned.
+    pub fn try_borrow_mut(&self) -> Result<RefMut<T>, InvalidBorrow> {
+        self.check_flag_write()?;
+
+        Ok(RefMut {
+            flag: &self.flag,
+            value: unsafe { &mut *self.inner.get() },
+        })
+    }
+
+    /// Gets exclusive access to the inner value, bypassing the Cell.
+    ///
+    /// Exclusive access is checked at compile time.
+    pub fn get_mut(&mut self) -> &mut T {
+        // safe because we have exclusive access via &mut self
+        unsafe { &mut *self.inner.get() }
+    }
+
+    /// Make sure we are allowed to aquire a read lock, and increment the read
+    /// count by 1
+    fn check_flag_read(&self) -> Result<(), InvalidBorrow> {
+        // Check that no write reference is out, then try to increment the read count
+        // and return once successful.
+        loop {
+            let val = self.flag.load(Ordering::Acquire);
+
+            if val == usize::MAX {
+                return Err(InvalidBorrow);
+            }
+
+            if self.flag.compare_and_swap(val, val + 1, Ordering::AcqRel) == val {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Make sure we are allowed to aquire a write lock, and then set the write
+    /// lock flag.
+    fn check_flag_write(&self) -> Result<(), InvalidBorrow> {
+        // Check we have 0 references out, and then set the ref count to usize::MAX to
+        // indicate a write lock.
+        match self.flag.compare_and_swap(0, usize::MAX, Ordering::AcqRel) {
+            0 => Ok(()),
+            _ => Err(InvalidBorrow),
+        }
+    }
+}
+
+unsafe impl<T> Sync for TrustCell<T> where T: Sync {}
+
+impl<T> Default for TrustCell<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        TrustCell::new(Default::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allow_multiple_reads() {
+        let cell: TrustCell<_> = TrustCell::new(5);
+
+        let a = cell.borrow();
+        let b = cell.borrow();
+
+        assert_eq!(10, *a + *b);
+    }
+
+    #[test]
+    fn allow_clone_reads() {
+        let cell: TrustCell<_> = TrustCell::new(5);
+
+        let a = cell.borrow();
+        let b = a.clone();
+
+        assert_eq!(10, *a + *b);
+    }
+
+    #[test]
+    fn allow_single_write() {
+        let cell: TrustCell<_> = TrustCell::new(5);
+
+        {
+            let mut a = cell.borrow_mut();
+            *a += 2;
+            *a += 3;
+        }
+
+        assert_eq!(10, *cell.borrow());
+    }
+
+    #[test]
+    #[should_panic(expected = "but it was already borrowed mutably")]
+    fn panic_write_and_read() {
+        let cell: TrustCell<_> = TrustCell::new(5);
+
+        let mut a = cell.borrow_mut();
+        *a = 7;
+
+        assert_eq!(7, *cell.borrow());
+    }
+
+    #[test]
+    #[should_panic(expected = "but it was already borrowed")]
+    fn panic_write_and_write() {
+        let cell: TrustCell<_> = TrustCell::new(5);
+
+        let mut a = cell.borrow_mut();
+        *a = 7;
+
+        assert_eq!(7, *cell.borrow_mut());
+    }
+
+    #[test]
+    #[should_panic(expected = "but it was already borrowed")]
+    fn panic_read_and_write() {
+        let cell: TrustCell<_> = TrustCell::new(5);
+
+        let _a = cell.borrow();
+
+        assert_eq!(7, *cell.borrow_mut());
+    }
+
+    #[test]
+    fn try_write_and_read() {
+        let cell: TrustCell<_> = TrustCell::new(5);
+
+        let mut a = cell.try_borrow_mut().unwrap();
+        *a = 7;
+
+        assert!(cell.try_borrow().is_err());
+    }
+
+    #[test]
+    fn try_write_and_write() {
+        let cell: TrustCell<_> = TrustCell::new(5);
+
+        let mut a = cell.try_borrow_mut().unwrap();
+        *a = 7;
+
+        assert!(cell.try_borrow_mut().is_err());
+    }
+
+    #[test]
+    fn try_read_and_write() {
+        let cell: TrustCell<_> = TrustCell::new(5);
+
+        let _a = cell.try_borrow().unwrap();
+
+        assert!(cell.try_borrow_mut().is_err());
+    }
+
+    #[test]
+    fn cloned_borrow_does_not_allow_write() {
+        let cell: TrustCell<_> = TrustCell::new(5);
+
+        let a = cell.borrow();
+        let _b = a.clone();
+        drop(a);
+
+        assert!(cell.try_borrow_mut().is_err());
+    }
+
+    #[test]
+    fn ref_with_non_sized() {
+        let r: Ref<'_, [i32]> = Ref {
+            flag: &AtomicUsize::new(1),
+            value: &[2, 3, 4, 5][..],
+        };
+
+        assert_eq!(&*r, &[2, 3, 4, 5][..]);
+    }
+
+    #[test]
+    fn ref_with_non_sized_clone() {
+        let r: Ref<'_, [i32]> = Ref {
+            flag: &AtomicUsize::new(1),
+            value: &[2, 3, 4, 5][..],
+        };
+        let rr = r.clone();
+
+        assert_eq!(&*r, &[2, 3, 4, 5][..]);
+        assert_eq!(r.flag.load(Ordering::SeqCst), 2);
+
+        assert_eq!(&*rr, &[2, 3, 4, 5][..]);
+        assert_eq!(rr.flag.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn ref_with_trait_obj() {
+        let ra: Ref<'_, dyn std::any::Any> = Ref {
+            flag: &AtomicUsize::new(1),
+            value: &2i32,
+        };
+
+        assert_eq!(ra.downcast_ref::<i32>().unwrap(), &2i32);
+    }
+
+    #[test]
+    fn ref_mut_with_non_sized() {
+        let mut r: RefMut<'_, [i32]> = RefMut {
+            flag: &AtomicUsize::new(1),
+            value: &mut [2, 3, 4, 5][..],
+        };
+
+        assert_eq!(&mut *r, &mut [2, 3, 4, 5][..]);
+    }
+
+    #[test]
+    fn ref_mut_with_trait_obj() {
+        let mut ra: RefMut<'_, dyn std::any::Any> = RefMut {
+            flag: &AtomicUsize::new(1),
+            value: &mut 2i32,
+        };
+
+        assert_eq!(ra.downcast_mut::<i32>().unwrap(), &mut 2i32);
+    }
+
+    #[test]
+    fn ref_map_box() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let r: Ref<'_, Box<usize>> = cell.borrow();
+        assert_eq!(&**r, &10);
+
+        let rr: Ref<'_, usize> = cell.borrow().map(Box::as_ref);
+        assert_eq!(&*rr, &10);
+    }
+
+    #[test]
+    fn ref_map_preserves_flag() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let r: Ref<'_, Box<usize>> = cell.borrow();
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 1);
+        let _nr: Ref<'_, usize> = r.map(Box::as_ref);
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn ref_map_retains_borrow() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let _r: Ref<'_, usize> = cell.borrow().map(Box::as_ref);
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 1);
+
+        let _rr: Ref<'_, usize> = cell.borrow().map(Box::as_ref);
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn ref_map_drops_borrow() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let r: Ref<'_, usize> = cell.borrow().map(Box::as_ref);
+
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 1);
+        drop(r);
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn ref_mut_map_box() {
+        let cell = TrustCell::new(Box::new(10));
+
+        {
+            let mut r: RefMut<'_, Box<usize>> = cell.borrow_mut();
+            assert_eq!(&mut **r, &mut 10);
+        }
+        {
+            let mut rr: RefMut<'_, usize> = cell.borrow_mut().map(Box::as_mut);
+            assert_eq!(&mut *rr, &mut 10);
+        }
+    }
+
+    #[test]
+    fn ref_mut_map_preserves_flag() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let r: RefMut<'_, Box<usize>> = cell.borrow_mut();
+        assert_eq!(cell.flag.load(Ordering::SeqCst), std::usize::MAX);
+        let _nr: RefMut<'_, usize> = r.map(Box::as_mut);
+        assert_eq!(cell.flag.load(Ordering::SeqCst), std::usize::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "but it was already borrowed")]
+    fn ref_mut_map_retains_mut_borrow() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let _rr: RefMut<'_, usize> = cell.borrow_mut().map(Box::as_mut);
+
+        let _ = cell.borrow_mut();
+    }
+
+    #[test]
+    fn ref_mut_map_drops_borrow() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let r: RefMut<'_, usize> = cell.borrow_mut().map(Box::as_mut);
+
+        assert_eq!(cell.flag.load(Ordering::SeqCst), std::usize::MAX);
+        drop(r);
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 0);
+    }
+}
+

--- a/src/utils/trust_cell.rs
+++ b/src/utils/trust_cell.rs
@@ -64,7 +64,7 @@ impl<'a, T: ?Sized> Ref<'a, T> {
     /// stored in the `TrustCell`.
     ///
     /// ```
-    /// use shred::cell::{Ref, TrustCell};
+    /// use wolf_engine::utils::trust_cell{Ref, TrustCell};
     ///
     /// let cb = TrustCell::new(Box::new(5));
     ///
@@ -83,7 +83,7 @@ impl<'a, T: ?Sized> Ref<'a, T> {
     /// value.
     ///
     /// ```rust
-    /// # use shred::cell::{TrustCell, Ref};
+    /// # use wolf_engine::utils::trust_cell{TrustCell, Ref};
     ///
     /// let c = TrustCell::new((5, 'b'));
     /// let b1: Ref<'_, (u32, char)> = c.borrow();
@@ -165,7 +165,7 @@ impl<'a, T: ?Sized> RefMut<'a, T> {
     /// stored in the `TrustCell`.
     ///
     /// ```
-    /// use shred::cell::{RefMut, TrustCell};
+    /// use wolf_engine::utils::trust_cell{RefMut, TrustCell};
     ///
     /// let cb = TrustCell::new(Box::new(5));
     ///
@@ -184,7 +184,7 @@ impl<'a, T: ?Sized> RefMut<'a, T> {
     /// value.
     ///
     /// ```rust
-    /// # use shred::cell::{TrustCell, RefMut};
+    /// # use wolf_engine::utils::trust_cell{TrustCell, RefMut};
     ///
     /// let c = TrustCell::new((5, 'b'));
     ///

--- a/src/utils/trust_cell.rs
+++ b/src/utils/trust_cell.rs
@@ -339,6 +339,7 @@ impl<T> TrustCell<T> {
                 return Err(InvalidBorrow);
             }
 
+            #[allow(deprecated)]
             if self.flag.compare_and_swap(val, val + 1, Ordering::AcqRel) == val {
                 return Ok(());
             }
@@ -350,6 +351,7 @@ impl<T> TrustCell<T> {
     fn check_flag_write(&self) -> Result<(), InvalidBorrow> {
         // Check we have 0 references out, and then set the ref count to usize::MAX to
         // indicate a write lock.
+        #[allow(deprecated)]
         match self.flag.compare_and_swap(0, usize::MAX, Ordering::AcqRel) {
             0 => Ok(()),
             _ => Err(InvalidBorrow),

--- a/src/utils/trust_cell.rs
+++ b/src/utils/trust_cell.rs
@@ -64,7 +64,7 @@ impl<'a, T: ?Sized> Ref<'a, T> {
     /// stored in the `TrustCell`.
     ///
     /// ```
-    /// use wolf_engine::utils::trust_cell{Ref, TrustCell};
+    /// use wolf_engine::utils::trust_cell::{Ref, TrustCell};
     ///
     /// let cb = TrustCell::new(Box::new(5));
     ///
@@ -83,7 +83,7 @@ impl<'a, T: ?Sized> Ref<'a, T> {
     /// value.
     ///
     /// ```rust
-    /// # use wolf_engine::utils::trust_cell{TrustCell, Ref};
+    /// # use wolf_engine::utils::trust_cell::{TrustCell, Ref};
     ///
     /// let c = TrustCell::new((5, 'b'));
     /// let b1: Ref<'_, (u32, char)> = c.borrow();
@@ -165,7 +165,7 @@ impl<'a, T: ?Sized> RefMut<'a, T> {
     /// stored in the `TrustCell`.
     ///
     /// ```
-    /// use wolf_engine::utils::trust_cell{RefMut, TrustCell};
+    /// use wolf_engine::utils::trust_cell::{RefMut, TrustCell};
     ///
     /// let cb = TrustCell::new(Box::new(5));
     ///
@@ -184,7 +184,7 @@ impl<'a, T: ?Sized> RefMut<'a, T> {
     /// value.
     ///
     /// ```rust
-    /// # use wolf_engine::utils::trust_cell{TrustCell, RefMut};
+    /// # use wolf_engine::utils::trust_cell::{TrustCell, RefMut};
     ///
     /// let c = TrustCell::new((5, 'b'));
     ///


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

This PR changes the `Context` object over to using a `TrustCell` to avoid issues with the borrow checker.

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

<!-- Select one (Delete the rest): -->

- Minor

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Added `utils::trust_cell` module copied from [Shred](https://github.com/amethyst/shred). 
  - [x] Added license and attribution in `licenses` file.
  - [x] Updated module paths for Wolf Engine.
  - [x] Ignored deprecation warnings in the module.
- [x] Updated `Context`.
  - [x] Changed `Context` to use `TrustCell`.
  - [x] Renamed `Context::get()` to `Context::borrow()`.
  - [x] Changed `Context::borrow()` return type to `Option<Ref<T>>`.
  - [x] Renamed `Context::get_mut()` to `Context::borrow_mut()`.
  - [x] Changed `Context::borrow_mut()` return type to `Option<RefMut<T>>`.
  - [x] Added `Context::try_borrow()`.
  - [x] Added `Context::try_borrow_mut()`. 
  - [x] Fixed issues created with the borrow checker when borrowing multiple, mutable `Subcontext`s.
  - [x] Removed `Context::empty()`.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All compiler warnings have been resolved.
  - [x] All Clippy warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relavent examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch.
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
