### PR TITLE
Bug/multi thread logging panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wolf_engine"
 description = "A game framework with a focus on flexibility and ease of use."
-version = "0.15.1"
+version = "0.15.2"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -30,6 +30,7 @@ pub fn initialize_logging(log_level: LevelFilter) {
     SimpleLogger::new()
         .with_colors(true)
         .with_level(log_level)
+        .with_utc_timestamps()
         .init()
         .expect("Failed to initialize the logger");
 }

--- a/tests/multi_thread_logging.rs
+++ b/tests/multi_thread_logging.rs
@@ -1,11 +1,17 @@
 #[cfg(test)]
 #[cfg(feature = "logging")]
 pub mod multi_threaded_logging_tests {
-    pub use wolf_engine::*;
-    pub use std::thread::Thread;
+    use wolf_engine::*;
+    use log::*;
+    use std::thread;
 
     #[test]
     pub fn should_not_panic_in_multi_threaded_environment() {
-    
+        logging::initialize_logging(LevelFilter::Info); 
+
+        let thread = thread::spawn(|| {
+            info!("Hello, world!"); 
+        });
+        thread.join().unwrap();
     }
 }

--- a/tests/multi_thread_logging.rs
+++ b/tests/multi_thread_logging.rs
@@ -1,16 +1,16 @@
 #[cfg(test)]
 #[cfg(feature = "logging")]
 pub mod multi_threaded_logging_tests {
-    use wolf_engine::*;
     use log::*;
     use std::thread;
+    use wolf_engine::*;
 
     #[test]
     pub fn should_not_panic_in_multi_threaded_environment() {
-        logging::initialize_logging(LevelFilter::Info); 
+        logging::initialize_logging(LevelFilter::Info);
 
         let thread = thread::spawn(|| {
-            info!("Hello, world!"); 
+            info!("Hello, world!");
         });
         thread.join().unwrap();
     }

--- a/tests/multi_thread_logging.rs
+++ b/tests/multi_thread_logging.rs
@@ -1,0 +1,11 @@
+#[cfg(test)]
+#[cfg(feature = "logging")]
+pub mod multi_threaded_logging_tests {
+    pub use wolf_engine::*;
+    pub use std::thread::Thread;
+
+    #[test]
+    pub fn should_not_panic_in_multi_threaded_environment() {
+    
+    }
+}


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

This PR fixes a bug with the default logging instance preventing it from working correctly in multi-threaded environments.

The panic: 

```
thread '<unnamed>' panicked at 'Could not determine the UTC offset on this system. Possible causes are that the time crate
does not implement "local_offset_at" on your system, or that you are running in a multi-threaded environment and the time 
crate is returning "None" from "local_offset_at" to avoid unsafe behaviour.
```

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

- Patch

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Changed the default logger to use UTC timestamps.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All compiler warnings have been resolved.
  - [x] All Clippy warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relavent examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch.
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
