### PR TITLE
Feature/profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wolf_engine"
 description = "A game framework with a focus on flexibility and ease of use."
-version = "0.15.2"
+version = "0.16.0"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.4"
 anymap = "0.12"
 rc_event_queue = "0.4"
 puffin = "0.13"
+anyhow = "1.0"
 
 # Optional Dependencies
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,5 @@ mockall = "0.11"
 
 [features]
 logging = ["simple_logger"]
+profiling = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/AlexiWolf/wolf_engine"
 log = "0.4"
 anymap = "0.12"
 rc_event_queue = "0.4"
+puffin = "0.13"
 
 # Optional Dependencies
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ puffin = "0.13"
 # Optional Dependencies
 
 simple_logger = {version = "1.13", optional = true}
+puffin_http = {version = "0.10", optional = true}
 
 [dev-dependencies]
 lazy_static= "1.4"
@@ -26,4 +27,5 @@ mockall = "0.11"
 [features]
 logging = ["simple_logger"]
 profiling = []
+http_profiling = ["profiling", "puffin_http"]
 

--- a/examples/profiling.rs
+++ b/examples/profiling.rs
@@ -1,0 +1,40 @@
+//! Run with `profiling` or `http_profiling` features enabled:
+//! 
+//! - `cargo run --example profiling --features profiling`
+//! or
+//! - `cargo run --example profiling --features http_profiling`
+//!
+//! If you run with `http_profiling`, you can use 
+//! [Puffin Viewer](https://crates.io/crates/puffin_viewer) to view the profiler output:
+//!
+//! 1. `cargo install puffin_viewer`
+//! 2. `puffin_viewer`
+
+use std::time::Duration;
+use std::thread::sleep;
+
+use wolf_engine::*;
+use wolf_engine::utils::{profile_function, profile_scope};
+
+pub fn main() {
+    Engine::new()
+        .run(Box::from(GameState));
+}
+
+pub struct GameState;
+
+impl State for GameState {
+    fn update(&mut self, _context: &mut Context) -> OptionalTransition {
+        // Set a custom name for the profiler scope.
+        profile_scope!("game_logic"); 
+        None
+    }
+
+
+    fn render(&mut self, _context: &mut Context) -> RenderResult {
+        // Allow Puffin to set profiler scope name based on the function name.
+        profile_function!(); 
+        sleep(Duration::from_millis(16)); // 60 fps.
+    }
+
+}

--- a/examples/profiling.rs
+++ b/examples/profiling.rs
@@ -1,24 +1,23 @@
 //! Run with `profiling` or `http_profiling` features enabled:
-//! 
+//!
 //! - `cargo run --example profiling --features profiling`
 //! or
 //! - `cargo run --example profiling --features http_profiling`
 //!
-//! If you run with `http_profiling`, you can use 
+//! If you run with `http_profiling`, you can use
 //! [Puffin Viewer](https://crates.io/crates/puffin_viewer) to view the profiler output:
 //!
 //! 1. `cargo install puffin_viewer`
 //! 2. `puffin_viewer`
 
-use std::time::Duration;
 use std::thread::sleep;
+use std::time::Duration;
 
-use wolf_engine::*;
 use wolf_engine::utils::{profile_function, profile_scope};
+use wolf_engine::*;
 
 pub fn main() {
-    Engine::new()
-        .run(Box::from(GameState));
+    Engine::new().run(Box::from(GameState));
 }
 
 pub struct GameState;
@@ -26,15 +25,13 @@ pub struct GameState;
 impl State for GameState {
     fn update(&mut self, _context: &mut Context) -> OptionalTransition {
         // Set a custom name for the profiler scope.
-        profile_scope!("game_logic"); 
+        profile_scope!("game_logic");
         None
     }
 
-
     fn render(&mut self, _context: &mut Context) -> RenderResult {
         // Allow Puffin to set profiler scope name based on the function name.
-        profile_function!(); 
+        profile_function!();
         sleep(Duration::from_millis(16)); // 60 fps.
     }
-
 }

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -1,5 +1,5 @@
 use log::*;
-use wolf_engine::{plugins::PuffinPlugin, *};
+use wolf_engine::*;
 
 pub fn main() {
     // If the "logging" feature is enabled, Wolf Engine includes a default logger for
@@ -11,10 +11,7 @@ pub fn main() {
     let game = FizzBuzzState::new();
 
     // Pass your state to the engine.  Have fun!
-    EngineBuilder::new()
-        .with_plugin(Box::from(PuffinPlugin))
-        .build()
-        .run(Box::from(game));
+    Engine::new().run(Box::from(game));
 }
 
 // Your game is implemented as one or many game states.  A game state stores all the

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -1,5 +1,5 @@
 use log::*;
-use wolf_engine::*;
+use wolf_engine::{plugins::PuffinPlugin, *};
 
 pub fn main() {
     // If the "logging" feature is enabled, Wolf Engine includes a default logger for
@@ -11,7 +11,10 @@ pub fn main() {
     let game = FizzBuzzState::new();
 
     // Pass your state to the engine.  Have fun!
-    Engine::new().run(Box::from(game));
+    EngineBuilder::new()
+        .with_plugin(Box::from(PuffinPlugin))
+        .build()
+        .run(Box::from(game));
 }
 
 // Your game is implemented as one or many game states.  A game state stores all the

--- a/src/contexts/mod.rs
+++ b/src/contexts/mod.rs
@@ -2,6 +2,10 @@
 
 mod event_context;
 mod scheduler_context;
+#[cfg(feature = "http_profiling")]
+mod puffin_http_context;
 
 pub use event_context::*;
 pub use scheduler_context::*;
+#[cfg(feature = "http_profiling")]
+pub use puffin_http_context::*;

--- a/src/contexts/mod.rs
+++ b/src/contexts/mod.rs
@@ -1,11 +1,11 @@
 //! Provides built-in [Subcontext](crate::Subcontext) implementations.
 
 mod event_context;
-mod scheduler_context;
 #[cfg(feature = "http_profiling")]
 mod puffin_http_context;
+mod scheduler_context;
 
 pub use event_context::*;
-pub use scheduler_context::*;
 #[cfg(feature = "http_profiling")]
 pub use puffin_http_context::*;
+pub use scheduler_context::*;

--- a/src/contexts/puffin_http_context.rs
+++ b/src/contexts/puffin_http_context.rs
@@ -1,11 +1,24 @@
+use puffin_http::{Server, Client};
+
 use crate::*;
 
-pub struct PuffinHttpContext {}
+pub struct PuffinHttpContext {
+    pub server: Server,
+    _client: Client,
+}
 
 impl PuffinHttpContext {
     pub fn new(server_address: &str) -> Result<Self, ()> {
-        let http_context = Self {};
-        Ok(http_context)
+        let server_result = Server::new(server_address);
+        if server_result.is_ok() {
+            let client = Client::new("127.0.0.1:8585".to_owned());
+            Ok(Self {
+                server: server_result.unwrap(),
+                _client: client
+            })
+        } else {
+            Err(server_result.err().unwrap())
+        }
     }
 }
 

--- a/src/contexts/puffin_http_context.rs
+++ b/src/contexts/puffin_http_context.rs
@@ -8,7 +8,7 @@ pub struct PuffinHttpContext {
 }
 
 impl PuffinHttpContext {
-    pub fn new(server_address: &str) -> Result<Self, ()> {
+    pub fn new(server_address: &str) -> Result<Self, anyhow::Error> {
         let server_result = Server::new(server_address);
         if server_result.is_ok() {
             let client = Client::new("127.0.0.1:8585".to_owned());

--- a/src/contexts/puffin_http_context.rs
+++ b/src/contexts/puffin_http_context.rs
@@ -1,0 +1,12 @@
+use crate::*;
+
+pub struct PuffinHttpContext {}
+
+impl PuffinHttpContext {
+    pub fn new() -> Result<Self, ()> {
+        let http_context = Self {};
+        Ok(http_context)
+    }
+}
+
+impl Subcontext for PuffinHttpContext {}

--- a/src/contexts/puffin_http_context.rs
+++ b/src/contexts/puffin_http_context.rs
@@ -1,4 +1,4 @@
-use puffin_http::{Server, Client};
+use puffin_http::{Client, Server};
 
 use crate::*;
 
@@ -14,7 +14,7 @@ impl PuffinHttpContext {
             let client = Client::new("127.0.0.1:8585".to_owned());
             Ok(Self {
                 server: server_result.unwrap(),
-                _client: client
+                _client: client,
             })
         } else {
             Err(server_result.err().unwrap())

--- a/src/contexts/puffin_http_context.rs
+++ b/src/contexts/puffin_http_context.rs
@@ -3,7 +3,7 @@ use crate::*;
 pub struct PuffinHttpContext {}
 
 impl PuffinHttpContext {
-    pub fn new() -> Result<Self, ()> {
+    pub fn new(server_address: &str) -> Result<Self, ()> {
         let http_context = Self {};
         Ok(http_context)
     }

--- a/src/contexts/puffin_http_context.rs
+++ b/src/contexts/puffin_http_context.rs
@@ -8,8 +8,8 @@ pub struct PuffinHttpContext {
 }
 
 impl PuffinHttpContext {
-    pub fn new(server_address: &str) -> Result<Self, anyhow::Error> {
-        let server_result = Server::new(server_address);
+    pub fn new() -> Result<Self, anyhow::Error> {
+        let server_result = Server::new("0.0.0.0:8585");
         if server_result.is_ok() {
             let client = Client::new("127.0.0.1:8585".to_owned());
             Ok(Self {

--- a/src/core/core_function.rs
+++ b/src/core/core_function.rs
@@ -61,6 +61,7 @@ pub type CoreFunction = Box<dyn Fn(Engine)>;
 /// [StateStack](crate::StateStack)is empty, then it will exit.
 pub fn run_while_has_active_state(mut engine: Engine) {
     while engine.state_stack.is_not_empty() {
+        puffin::GlobalProfiler::lock().new_frame();
         puffin::profile_scope!("frame");
         engine
             .scheduler

--- a/src/core/core_function.rs
+++ b/src/core/core_function.rs
@@ -63,10 +63,10 @@ pub fn run_while_has_active_state(mut engine: Engine) {
     while engine.state_stack.is_not_empty() {
         engine
             .scheduler
-            .update(&mut engine.context, &mut engine.state_stack);
+            .start_update(&mut engine.context, &mut engine.state_stack);
         engine
             .scheduler
-            .render(&mut engine.context, &mut engine.state_stack);
+            .start_render(&mut engine.context, &mut engine.state_stack);
     }
     log::debug!("The state stack is empty.  The engine will now shut down.")
 }

--- a/src/core/core_function.rs
+++ b/src/core/core_function.rs
@@ -63,10 +63,10 @@ pub fn run_while_has_active_state(mut engine: Engine) {
     while engine.state_stack.is_not_empty() {
         engine
             .scheduler
-            .start_update(&mut engine.context, &mut engine.state_stack);
+            .profile_update(&mut engine.context, &mut engine.state_stack);
         engine
             .scheduler
-            .start_render(&mut engine.context, &mut engine.state_stack);
+            .profile_render(&mut engine.context, &mut engine.state_stack);
     }
     log::debug!("The state stack is empty.  The engine will now shut down.")
 }

--- a/src/core/core_function.rs
+++ b/src/core/core_function.rs
@@ -61,6 +61,7 @@ pub type CoreFunction = Box<dyn Fn(Engine)>;
 /// [StateStack](crate::StateStack)is empty, then it will exit.
 pub fn run_while_has_active_state(mut engine: Engine) {
     while engine.state_stack.is_not_empty() {
+        puffin::profile_scope!("frame");
         engine
             .scheduler
             .profile_update(&mut engine.context, &mut engine.state_stack);

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -209,7 +209,7 @@ mod engine_builder_tests {
     use super::*;
 
     #[test]
-    fn should_allow_custom_states() {
+    fn should_allow_custom_schedulers() {
         let mut scheduler = MockScheduler::new();
         scheduler
             .expect_start_update()

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -209,7 +209,7 @@ mod engine_builder_tests {
     use super::*;
 
     #[test]
-    fn should_allow_custom_schedulers() {
+    fn should_set_custom_scheduler() {
         let mut scheduler = MockScheduler::new();
         scheduler
             .expect_start_update()

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -212,12 +212,12 @@ mod engine_builder_tests {
     fn should_set_custom_scheduler() {
         let mut scheduler = MockScheduler::new();
         scheduler
-            .expect_start_update()
+            .expect_profile_update()
             .times(1..)
             .returning(|context, state_stack| {
                 state_stack.update(context);
             });
-        scheduler.expect_start_render().times(..).return_const(());
+        scheduler.expect_profile_render().times(..).return_const(());
         scheduler.expect_render().times(..).return_const(());
 
         EngineBuilder::new()

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -217,6 +217,7 @@ mod engine_builder_tests {
             .returning(|context, state_stack| {
                 state_stack.update(context);
             });
+        scheduler.expect_update().times(..).return_const(());
         scheduler.expect_profile_render().times(..).return_const(());
         scheduler.expect_render().times(..).return_const(());
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -213,11 +213,7 @@ mod engine_builder_tests {
         let mut scheduler = MockScheduler::new();
         scheduler
             .expect_start_update()
-            .times(1)
-            .returning(|_, _| {});
-        scheduler
-            .expect_update()
-            .times(1)
+            .times(1..)
             .returning(|context, state_stack| {
                 state_stack.update(context);
             });

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1,6 +1,6 @@
 use std::mem::replace;
 
-use crate::plugins::CorePlugin;
+use crate::plugins::{CorePlugin, PuffinPlugin};
 use crate::schedulers::FixedUpdateScheduler;
 use crate::*;
 
@@ -169,6 +169,7 @@ impl Default for EngineBuilder {
             plugin_loader: PluginLoader::new(),
         }
         .with_plugin(Box::from(CorePlugin))
+        .with_plugin(Box::from(PuffinPlugin))
         .with_engine_core(Box::from(run_while_has_active_state))
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -212,11 +212,16 @@ mod engine_builder_tests {
     fn should_allow_custom_states() {
         let mut scheduler = MockScheduler::new();
         scheduler
+            .expect_start_update()
+            .times(1)
+            .returning(|_, _| {});
+        scheduler
             .expect_update()
             .times(1)
             .returning(|context, state_stack| {
                 state_stack.update(context);
             });
+        scheduler.expect_start_render().times(..).return_const(());
         scheduler.expect_render().times(..).return_const(());
 
         EngineBuilder::new()

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -84,14 +84,14 @@ pub type Frames = u64;
 #[cfg_attr(test, automock)]
 pub trait Scheduler {
     fn start_update(&mut self, context: &mut Context, state: &mut dyn State) {
-        
+        self.update(context, state); 
     }
 
     /// Update the game state.
     fn update(&mut self, context: &mut Context, state: &mut dyn State);
 
     fn start_render(&mut self, context: &mut Context, state: &mut dyn State) {
-
+        self.render(context, state);
     }
 
     /// Render the game state.

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -85,7 +85,7 @@ pub type Frames = u64;
 pub trait Scheduler {
     /// Profiles the [Scheduler::update()] method.
     ///
-    /// **Warning:** This method private API and SHOULD NOT be used by 3rd party code.
+    /// **Warning:** This method is private API and SHOULD NOT be used by 3rd party code.
     /// It is subject to change at any time, and without warning.
     #[doc(hidden)]
     fn profile_update(&mut self, context: &mut Context, state: &mut dyn State) {
@@ -98,7 +98,7 @@ pub trait Scheduler {
 
     /// Profiles the [Scheduler::render()] method.
     ///
-    /// **Warning:** This method private API and SHOULD NOT be used by 3rd party code.
+    /// **Warning:** This method is private API and SHOULD NOT be used by 3rd party code.
     /// It is subject to change at any time, and without warning.
     #[doc(hidden)]
     fn profile_render(&mut self, context: &mut Context, state: &mut dyn State) {

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -86,7 +86,7 @@ pub trait Scheduler {
     /// Profiles the [Scheduler::update()] method.
     ///
     /// **Warning:** This method is private API and SHOULD NOT be used by 3rd party code.
-    /// It is subject to change at any time, and without warning.
+    /// It is subject to change at any time without warning.
     #[doc(hidden)]
     fn profile_update(&mut self, context: &mut Context, state: &mut dyn State) {
         puffin::profile_scope!("update");
@@ -99,7 +99,7 @@ pub trait Scheduler {
     /// Profiles the [Scheduler::render()] method.
     ///
     /// **Warning:** This method is private API and SHOULD NOT be used by 3rd party code.
-    /// It is subject to change at any time, and without warning.
+    /// It is subject to change at any time without warning.
     #[doc(hidden)]
     fn profile_render(&mut self, context: &mut Context, state: &mut dyn State) {
         puffin::profile_scope!("render");

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -90,7 +90,7 @@ pub trait Scheduler {
     #[doc(hidden)]
     fn profile_update(&mut self, context: &mut Context, state: &mut dyn State) {
         puffin::profile_scope!("update");
-        self.update(context, state); 
+        self.update(context, state);
     }
 
     /// Update the game state.
@@ -105,7 +105,7 @@ pub trait Scheduler {
         puffin::profile_scope!("render");
         self.render(context, state);
     }
-    
+
     /// Render the game state.
     fn render(&mut self, context: &mut Context, state: &mut dyn State);
 }

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -89,6 +89,7 @@ pub trait Scheduler {
     /// It is subject to change at any time, and without warning.
     #[doc(hidden)]
     fn profile_update(&mut self, context: &mut Context, state: &mut dyn State) {
+        puffin::profile_scope!("update");
         self.update(context, state); 
     }
 
@@ -101,6 +102,7 @@ pub trait Scheduler {
     /// It is subject to change at any time, and without warning.
     #[doc(hidden)]
     fn profile_render(&mut self, context: &mut Context, state: &mut dyn State) {
+        puffin::profile_scope!("render");
         self.render(context, state);
     }
     

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -89,7 +89,7 @@ pub trait Scheduler {
 
     /// Update the game state.
     fn update(&mut self, context: &mut Context, state: &mut dyn State);
-t
+
     fn profile_render(&mut self, context: &mut Context, state: &mut dyn State) {
         self.render(context, state);
     }

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -83,8 +83,16 @@ pub type Frames = u64;
 /// ```
 #[cfg_attr(test, automock)]
 pub trait Scheduler {
+    fn start_update(&mut self, context: &mut Context, state: &mut dyn State) {
+        
+    }
+
     /// Update the game state.
     fn update(&mut self, context: &mut Context, state: &mut dyn State);
+
+    fn start_render(&mut self, context: &mut Context, state: &mut dyn State) {
+
+    }
 
     /// Render the game state.
     fn render(&mut self, context: &mut Context, state: &mut dyn State);

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -83,21 +83,17 @@ pub type Frames = u64;
 /// ```
 #[cfg_attr(test, automock)]
 pub trait Scheduler {
-    /// Update the game state.
-    fn update(&mut self, context: &mut Context, state: &mut dyn State);
-
-    /// Render the game state.
-    fn render(&mut self, context: &mut Context, state: &mut dyn State);
-}
-
-pub trait ProfilingScheduler: Scheduler {
     fn start_update(&mut self, context: &mut Context, state: &mut dyn State) {
         self.update(context, state); 
     }
 
+    /// Update the game state.
+    fn update(&mut self, context: &mut Context, state: &mut dyn State);
+
     fn start_render(&mut self, context: &mut Context, state: &mut dyn State) {
         self.render(context, state);
     }
+    
+    /// Render the game state.
+    fn render(&mut self, context: &mut Context, state: &mut dyn State);
 }
-
-impl<T: Scheduler> ProfilingScheduler for T {}

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -83,6 +83,11 @@ pub type Frames = u64;
 /// ```
 #[cfg_attr(test, automock)]
 pub trait Scheduler {
+    /// Profiles the [Scheduler::update()] method.
+    ///
+    /// **Warning:** This method private API and SHOULD NOT be used by 3rd party code.
+    /// It is subject to change at any time, and without warning.
+    #[doc(hidden)]
     fn profile_update(&mut self, context: &mut Context, state: &mut dyn State) {
         self.update(context, state); 
     }
@@ -90,6 +95,11 @@ pub trait Scheduler {
     /// Update the game state.
     fn update(&mut self, context: &mut Context, state: &mut dyn State);
 
+    /// Profiles the [Scheduler::render()] method.
+    ///
+    /// **Warning:** This method private API and SHOULD NOT be used by 3rd party code.
+    /// It is subject to change at any time, and without warning.
+    #[doc(hidden)]
     fn profile_render(&mut self, context: &mut Context, state: &mut dyn State) {
         self.render(context, state);
     }

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -87,6 +87,7 @@ pub trait Scheduler {
     ///
     /// **Warning:** This method private API and SHOULD NOT be used by 3rd party code.
     /// It is subject to change at any time, and without warning.
+    #[doc(hidden)]
     fn profile_update(&mut self, context: &mut Context, state: &mut dyn State) {
         self.update(context, state); 
     }
@@ -98,6 +99,7 @@ pub trait Scheduler {
     ///
     /// **Warning:** This method private API and SHOULD NOT be used by 3rd party code.
     /// It is subject to change at any time, and without warning.
+    #[doc(hidden)]
     fn profile_render(&mut self, context: &mut Context, state: &mut dyn State) {
         self.render(context, state);
     }

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -83,17 +83,21 @@ pub type Frames = u64;
 /// ```
 #[cfg_attr(test, automock)]
 pub trait Scheduler {
-    fn start_update(&mut self, context: &mut Context, state: &mut dyn State) {
-        self.update(context, state); 
-    }
-
     /// Update the game state.
     fn update(&mut self, context: &mut Context, state: &mut dyn State);
-
-    fn start_render(&mut self, context: &mut Context, state: &mut dyn State) {
-        self.render(context, state);
-    }
 
     /// Render the game state.
     fn render(&mut self, context: &mut Context, state: &mut dyn State);
 }
+
+pub trait ProfilingScheduler: Scheduler {
+    fn start_update(&mut self, context: &mut Context, state: &mut dyn State) {
+        self.update(context, state); 
+    }
+
+    fn start_render(&mut self, context: &mut Context, state: &mut dyn State) {
+        self.render(context, state);
+    }
+}
+
+impl<T: Scheduler> ProfilingScheduler for T {}

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -87,7 +87,6 @@ pub trait Scheduler {
     ///
     /// **Warning:** This method private API and SHOULD NOT be used by 3rd party code.
     /// It is subject to change at any time, and without warning.
-    #[doc(hidden)]
     fn profile_update(&mut self, context: &mut Context, state: &mut dyn State) {
         self.update(context, state); 
     }
@@ -99,7 +98,6 @@ pub trait Scheduler {
     ///
     /// **Warning:** This method private API and SHOULD NOT be used by 3rd party code.
     /// It is subject to change at any time, and without warning.
-    #[doc(hidden)]
     fn profile_render(&mut self, context: &mut Context, state: &mut dyn State) {
         self.render(context, state);
     }

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -83,14 +83,14 @@ pub type Frames = u64;
 /// ```
 #[cfg_attr(test, automock)]
 pub trait Scheduler {
-    fn start_update(&mut self, context: &mut Context, state: &mut dyn State) {
+    fn profile_update(&mut self, context: &mut Context, state: &mut dyn State) {
         self.update(context, state); 
     }
 
     /// Update the game state.
     fn update(&mut self, context: &mut Context, state: &mut dyn State);
-
-    fn start_render(&mut self, context: &mut Context, state: &mut dyn State) {
+t
+    fn profile_render(&mut self, context: &mut Context, state: &mut dyn State) {
         self.render(context, state);
     }
     

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,5 +1,7 @@
 //! Provides built-in [Plugin](crate::Plugin) implementations.
 
 mod core_plugin;
+mod puffin_plugin;
 
 pub(crate) use core_plugin::*;
+pub use puffin_plugin::*;

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -5,7 +5,7 @@ pub struct PuffinPlugin;
 
 impl Plugin for PuffinPlugin {
     fn setup(&mut self,engine_builder:EngineBuilder) -> PluginResult {
+        puffin::set_scopes_on(true);
         Ok(engine_builder)
     }
-
 }

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -10,8 +10,7 @@ impl Plugin for PuffinPlugin {
         }
         if cfg!(feature = "http_profiling") {
             use contexts::PuffinHttpContext;
-            let server_address = "0.0.0.0:8585";
-            let puffin_server_result = PuffinHttpContext::new(server_address);
+            let puffin_server_result = PuffinHttpContext::new();
         }
         Ok(engine_builder)
     }

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -1,17 +1,29 @@
 use crate::*;
+use log::*;
 
 /// Provides profiling using [puffin].
 pub struct PuffinPlugin;
 
 impl Plugin for PuffinPlugin {
-    fn setup(&mut self,engine_builder:EngineBuilder) -> PluginResult {
+    fn setup(&mut self, mut engine_builder: EngineBuilder) -> PluginResult {
         if cfg!(feature = "profiling") {
             puffin::set_scopes_on(true);
         }
-        if cfg!(feature = "http_profiling") {
-            use contexts::PuffinHttpContext;
-            let puffin_server_result = PuffinHttpContext::new();
-        }
+        #[cfg(feature = "http_profiling")]
+        {engine_builder = enable_puffin_http(engine_builder);}
         Ok(engine_builder)
     }
+}
+
+#[cfg(feature = "http_profiling")]
+fn enable_puffin_http(mut engine_builder: EngineBuilder) -> EngineBuilder {
+    let puffin_server_result = contexts::PuffinHttpContext::new();
+    if puffin_server_result.is_ok() {
+        let http_context = puffin_server_result.unwrap();
+        info!("Successfully created Puffin HTTP server at: 0.0.0.0:8585");
+        engine_builder = engine_builder.with_subcontext(http_context);
+    } else {
+        warn!("Failed to create Puffin HTTP server at: 0.0.0.0:8585: {}", puffin_server_result.err().unwrap());
+    }
+    engine_builder
 }

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -1,10 +1,10 @@
 use crate::*;
-use log::*;
 
 /// Provides profiling using [puffin].
 pub struct PuffinPlugin;
 
 impl Plugin for PuffinPlugin {
+    #[allow(unused_mut)]
     fn setup(&mut self, mut engine_builder: EngineBuilder) -> PluginResult {
         if cfg!(feature = "profiling") {
             puffin::set_scopes_on(true);
@@ -22,10 +22,10 @@ fn enable_puffin_http(mut engine_builder: EngineBuilder) -> EngineBuilder {
     let puffin_server_result = contexts::PuffinHttpContext::new();
     if puffin_server_result.is_ok() {
         let http_context = puffin_server_result.unwrap();
-        info!("Successfully created Puffin HTTP server at: 0.0.0.0:8585");
+        log::info!("Successfully created Puffin HTTP server at: 0.0.0.0:8585");
         engine_builder = engine_builder.with_subcontext(http_context);
     } else {
-        warn!(
+        log::warn!(
             "Failed to create Puffin HTTP server at: 0.0.0.0:8585: {}",
             puffin_server_result.err().unwrap()
         );

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -5,7 +5,9 @@ pub struct PuffinPlugin;
 
 impl Plugin for PuffinPlugin {
     fn setup(&mut self,engine_builder:EngineBuilder) -> PluginResult {
-        puffin::set_scopes_on(true);
+        if cfg!(feature = "profiling") {
+            puffin::set_scopes_on(true);
+        }
         Ok(engine_builder)
     }
 }

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -1,4 +1,4 @@
-use crate::{*, contexts::*};
+use crate::*;
 
 /// Provides profiling using [puffin].
 pub struct PuffinPlugin;
@@ -9,6 +9,7 @@ impl Plugin for PuffinPlugin {
             puffin::set_scopes_on(true);
         }
         if cfg!(feature = "http_profiling") {
+            use contexts::PuffinHttpContext;
             let puffin_server_result = PuffinHttpContext::new();
         }
         Ok(engine_builder)

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use crate::{*, contexts::PuffinHttpContext};
 
 /// Provides profiling using [puffin].
 pub struct PuffinPlugin;

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -1,0 +1,10 @@
+use crate::*;
+
+pub struct PuffinPlugin;
+
+impl Plugin for PuffinPlugin {
+    fn setup(&mut self,engine_builder:EngineBuilder) -> PluginResult {
+        Ok(engine_builder)
+    }
+
+}

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -1,4 +1,4 @@
-use crate::{*, contexts::PuffinHttpContext};
+use crate::{*, contexts::*};
 
 /// Provides profiling using [puffin].
 pub struct PuffinPlugin;

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -8,6 +8,9 @@ impl Plugin for PuffinPlugin {
         if cfg!(feature = "profiling") {
             puffin::set_scopes_on(true);
         }
+        if cfg!(feature = "http_profiling") {
+            let puffin_server_result = PuffinHttpContext::new();
+        }
         Ok(engine_builder)
     }
 }

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -1,5 +1,6 @@
 use crate::*;
 
+/// Provides profiling using [puffin].
 pub struct PuffinPlugin;
 
 impl Plugin for PuffinPlugin {

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -10,7 +10,8 @@ impl Plugin for PuffinPlugin {
         }
         if cfg!(feature = "http_profiling") {
             use contexts::PuffinHttpContext;
-            let puffin_server_result = PuffinHttpContext::new();
+            let server_address = "0.0.0.0:8585";
+            let puffin_server_result = PuffinHttpContext::new(server_address);
         }
         Ok(engine_builder)
     }

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -10,7 +10,9 @@ impl Plugin for PuffinPlugin {
             puffin::set_scopes_on(true);
         }
         #[cfg(feature = "http_profiling")]
-        {engine_builder = enable_puffin_http(engine_builder);}
+        {
+            engine_builder = enable_puffin_http(engine_builder);
+        }
         Ok(engine_builder)
     }
 }
@@ -23,7 +25,10 @@ fn enable_puffin_http(mut engine_builder: EngineBuilder) -> EngineBuilder {
         info!("Successfully created Puffin HTTP server at: 0.0.0.0:8585");
         engine_builder = engine_builder.with_subcontext(http_context);
     } else {
-        warn!("Failed to create Puffin HTTP server at: 0.0.0.0:8585: {}", puffin_server_result.err().unwrap());
+        warn!(
+            "Failed to create Puffin HTTP server at: 0.0.0.0:8585: {}",
+            puffin_server_result.err().unwrap()
+        );
     }
     engine_builder
 }

--- a/src/schedulers/fixed_update_scheduler.rs
+++ b/src/schedulers/fixed_update_scheduler.rs
@@ -145,6 +145,7 @@ impl FixedUpdateScheduler {
 
     fn run_tick_loop(&mut self, state: &mut dyn State, context: &mut Context) {
         while self.can_run_a_tick() {
+            puffin::profile_scope!("tick");
             trace!("Running Tick: {}", self);
             self.tick(state, context);
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,4 +2,4 @@
 
 pub mod trust_cell;
 
-pub use puffin::{profile_function, profile_scope, current_file_name, current_function_name};
+pub use puffin::{current_file_name, current_function_name, profile_function, profile_scope};

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,5 @@
 //! Provides common helpers and utilities.
 
 pub mod trust_cell;
+
+pub use puffin::{profile_function, profile_scope, current_file_name, current_function_name};


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

This PR adds profiling, and http profiling support using [Puffin](https://crates.io/crates/puffin).

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

<!-- Select one (Delete the rest): -->

- Minor

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Added `profiling` feature flag.
- [x] Added `http_profiling` feature flag.
- [x] Added `puffin` to dependencies.
- [x] Added `puffin_http` to optional dependencies.
- [x] Added `anyhow` to dependencies.
- [x] Added `Scheduler::profile_update()` method.
- [x] Added `Scheduler::profile_render()` method.
- [x] Added `PuffinPlugin`.
  - [x] Added `PuffinPlugin` to be added automatically when the `EngineBuilder` is created.
- [x] Added `PuffinHttpContext`.
- [x] Added profiling scopes to relevant functions:
  - [x] Changed the main loop to start a new frame each iteration.
  - [x] Changed main loop to call `Scheduler::profile_update()` instead of `Scheduler::update()`.
  - [x] Changed main loop to call `Scheduler::profile_render()` instead of `Scheduler::render()`.
  - [x] Added `frame` profile scope to main loop.
  - [x] Added `tick` profile scope to `FixedUpdateScheduler`.
- [x] Reexported common `puffin` macros in the `utils` module.
- [x] Added `profiling` example.
 
# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All compiler warnings have been resolved.
  - [x] All Clippy warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relavent examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch.
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
