### PR TITLE
Fix/remove automatic profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wolf_engine"
 description = "A game framework with a focus on flexibility and ease of use."
-version = "0.17.0"
+version = "0.17.1"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/profiling.rs
+++ b/examples/profiling.rs
@@ -13,11 +13,15 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use wolf_engine::utils::{profile_function, profile_scope};
 use wolf_engine::*;
+use wolf_engine::plugins::PuffinPlugin;
+use wolf_engine::utils::{profile_function, profile_scope};
 
 pub fn main() {
-    Engine::new().run(Box::from(GameState));
+    EngineBuilder::new()
+        .with_plugin(Box::from(PuffinPlugin))
+        .build()
+        .run(Box::from(GameState));
 }
 
 pub struct GameState;

--- a/examples/profiling.rs
+++ b/examples/profiling.rs
@@ -16,8 +16,12 @@ use std::time::Duration;
 use wolf_engine::*;
 use wolf_engine::plugins::PuffinPlugin;
 use wolf_engine::utils::{profile_function, profile_scope};
+use log::*;
 
 pub fn main() {
+    #[cfg(feature = "logging")]
+    logging::initialize_logging(LevelFilter::Debug);
+
     EngineBuilder::new()
         .with_plugin(Box::from(PuffinPlugin))
         .build()

--- a/examples/profiling.rs
+++ b/examples/profiling.rs
@@ -13,10 +13,10 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use wolf_engine::*;
+use log::*;
 use wolf_engine::plugins::PuffinPlugin;
 use wolf_engine::utils::{profile_function, profile_scope};
-use log::*;
+use wolf_engine::*;
 
 pub fn main() {
     #[cfg(feature = "logging")]

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1,6 +1,6 @@
 use std::mem::replace;
 
-use crate::plugins::{CorePlugin, PuffinPlugin};
+use crate::plugins::CorePlugin;
 use crate::schedulers::FixedUpdateScheduler;
 use crate::*;
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -169,7 +169,6 @@ impl Default for EngineBuilder {
             plugin_loader: PluginLoader::new(),
         }
         .with_plugin(Box::from(CorePlugin))
-        .with_plugin(Box::from(PuffinPlugin))
         .with_engine_core(Box::from(run_while_has_active_state))
     }
 }


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

Removed automatic initialization of the `PuffinPlugin` from the default `EngineBuilder`.  It should be up to the user whether or not to load the profiler, not Wolf Engine.

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

<!-- Select one (Delete the rest): -->

- Patch

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Removed automatic `PuffinPlugin` initialization.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All compiler warnings have been resolved.
  - [x] All Clippy warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relavent examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch.
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
