### PR TITLE
Refactor/engine functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wolf_engine"
 description = "A game framework with a focus on flexibility and ease of use."
-version = "0.17.1"
+version = "0.18.0"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/profiling.rs
+++ b/examples/profiling.rs
@@ -13,14 +13,13 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use log::*;
 use wolf_engine::plugins::PuffinPlugin;
 use wolf_engine::utils::{profile_function, profile_scope};
 use wolf_engine::*;
 
 pub fn main() {
     #[cfg(feature = "logging")]
-    logging::initialize_logging(LevelFilter::Debug);
+    logging::initialize_logging(log::LevelFilter::Debug);
 
     EngineBuilder::new()
         .with_plugin(Box::from(PuffinPlugin))

--- a/src/contexts/puffin_http_context.rs
+++ b/src/contexts/puffin_http_context.rs
@@ -10,10 +10,10 @@ pub struct PuffinHttpContext {
 impl PuffinHttpContext {
     pub fn new() -> Result<Self, anyhow::Error> {
         let server_result = Server::new("0.0.0.0:8585");
-        if server_result.is_ok() {
+        if let Ok(server) = server_result {
             let client = Client::new("127.0.0.1:8585".to_owned());
             Ok(Self {
-                server: server_result.unwrap(),
+                server,
                 _client: client,
             })
         } else {

--- a/src/core/core_function.rs
+++ b/src/core/core_function.rs
@@ -31,8 +31,7 @@ use crate::Engine;
 /// pub fn custom_engine_core(mut engine: Engine) {
 ///     while engine.is_running() {
 ///         engine.update();
-///         engine.scheduler
-///             .render(&mut engine.context, &mut engine.state_stack);
+///         engine.render();
 /// #       break
 ///     }
 /// }

--- a/src/core/core_function.rs
+++ b/src/core/core_function.rs
@@ -30,8 +30,7 @@ use crate::Engine;
 /// #
 /// pub fn custom_engine_core(mut engine: Engine) {
 ///     while engine.is_running() {
-///         engine.scheduler
-///             .update(&mut engine.context, &mut engine.state_stack);
+///         engine.update();
 ///         engine.scheduler
 ///             .render(&mut engine.context, &mut engine.state_stack);
 /// #       break

--- a/src/core/core_function.rs
+++ b/src/core/core_function.rs
@@ -29,7 +29,7 @@ use crate::Engine;
 /// # use wolf_engine::*;
 /// #
 /// pub fn custom_engine_core(mut engine: Engine) {
-///     loop {
+///     while engine.is_running() {
 ///         engine.scheduler
 ///             .update(&mut engine.context, &mut engine.state_stack);
 ///         engine.scheduler

--- a/src/core/core_function.rs
+++ b/src/core/core_function.rs
@@ -61,12 +61,8 @@ pub fn run_while_has_active_state(mut engine: Engine) {
     while engine.state_stack.is_not_empty() {
         puffin::GlobalProfiler::lock().new_frame();
         puffin::profile_scope!("frame");
-        engine
-            .scheduler
-            .profile_update(&mut engine.context, &mut engine.state_stack);
-        engine
-            .scheduler
-            .profile_render(&mut engine.context, &mut engine.state_stack);
+        engine.update();
+        engine.render();
     }
     log::debug!("The state stack is empty.  The engine will now shut down.")
 }

--- a/src/core/core_function.rs
+++ b/src/core/core_function.rs
@@ -30,6 +30,7 @@ use crate::Engine;
 /// #
 /// pub fn custom_engine_core(mut engine: Engine) {
 ///     while engine.is_running() {
+///         engine.start_frame();
 ///         engine.update();
 ///         engine.render();
 /// #       break

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -111,6 +111,28 @@ impl Default for Engine {
     }
 }
 
+#[cfg(test)]
+mod wolf_engine_tests {
+    use crate::{MockState, Transition};
+
+    use super::*;
+
+    #[test]
+    fn should_run_the_state() {
+        let wolf_engine = Engine::default();
+        let mut state = MockState::new();
+        state.expect_setup().times(..).returning(|_| ());
+        state
+            .expect_update()
+            .times(1..)
+            .returning(|_| Some(Transition::Quit));
+        state.expect_render().times(1..).returning(|_| ());
+        state.expect_shutdown().times(1).returning(|_| ());
+
+        wolf_engine.run(Box::from(state));
+    }
+}
+
 /// Build and customize an instance of the [Engine].
 ///
 /// The two main jobs of the engine builder is to load [Plugin]s and allow users to
@@ -170,28 +192,6 @@ impl Default for EngineBuilder {
         }
         .with_plugin(Box::from(CorePlugin))
         .with_engine_core(Box::from(run_while_has_active_state))
-    }
-}
-
-#[cfg(test)]
-mod wolf_engine_tests {
-    use crate::{MockState, Transition};
-
-    use super::*;
-
-    #[test]
-    fn should_run_the_state() {
-        let wolf_engine = Engine::default();
-        let mut state = MockState::new();
-        state.expect_setup().times(..).returning(|_| ());
-        state
-            .expect_update()
-            .times(1..)
-            .returning(|_| Some(Transition::Quit));
-        state.expect_render().times(1..).returning(|_| ());
-        state.expect_shutdown().times(1).returning(|_| ());
-
-        wolf_engine.run(Box::from(state));
     }
 }
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -116,6 +116,10 @@ impl Engine {
     pub fn update(&mut self) {
 
     }
+
+    pub fn render(&mut self) {
+
+    }
 }
 
 impl Default for Engine {

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -103,7 +103,12 @@ impl Engine {
             core: Box::from(|_| {}),
         }
     }
-
+    
+    /// Returns true if the engine is running.
+    ///
+    /// The engine is considered to be running when the following conditions are met:
+    ///
+    /// - There is at least one [State] on the [StateStack].
     pub fn is_running(&self) -> bool {
         self.state_stack.is_not_empty() 
     }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -116,7 +116,7 @@ impl Engine {
     pub fn update(&mut self) {
         self
             .scheduler
-            .profile_update(&mut self.context, &mut self.state_stack);
+            .update(&mut self.context, &mut self.state_stack);
     }
 
     pub fn render(&mut self) {
@@ -250,13 +250,11 @@ mod engine_builder_tests {
     fn should_set_custom_scheduler() {
         let mut scheduler = MockScheduler::new();
         scheduler
-            .expect_profile_update()
+            .expect_update()
             .times(1..)
             .returning(|context, state_stack| {
                 state_stack.update(context);
             });
-        scheduler.expect_update().times(..).return_const(());
-        scheduler.expect_profile_render().times(..).return_const(());
         scheduler.expect_render().times(..).return_const(());
 
         EngineBuilder::new()

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -112,6 +112,10 @@ impl Engine {
     pub fn is_running(&self) -> bool {
         self.state_stack.is_not_empty() 
     }
+
+    pub fn update(&mut self) {
+
+    }
 }
 
 impl Default for Engine {

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -131,6 +131,15 @@ mod wolf_engine_tests {
 
         wolf_engine.run(Box::from(state));
     }
+
+    #[test]
+    fn should_indicate_is_running_if_state_is_loaded() {
+        let mut engine = Engine::default(); 
+        let mut state = MockState::new();
+        state.expect_setup().times(1).returning(|_| ());
+
+        assert!(engine.is_running(), "The Engine should not be running.");
+    }
 }
 
 /// Build and customize an instance of the [Engine].

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -112,14 +112,16 @@ impl Engine {
     pub fn is_running(&self) -> bool {
         self.state_stack.is_not_empty() 
     }
-
+    
+    /// Runs a complete update of all engine and game state.
     pub fn update(&mut self) {
         puffin::profile_scope!("update");
         self
             .scheduler
             .update(&mut self.context, &mut self.state_stack);
     }
-
+    
+    /// Renders the current frame.
     pub fn render(&mut self) {
         puffin::profile_scope!("render");
         self

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -145,6 +145,13 @@ mod wolf_engine_tests {
 
         assert!(engine.is_running(), "The Engine should not be running.");
     }
+
+    #[test]
+    fn should_not_indicate_is_running_if_no_state_is_loaded() {
+        let engine = Engine::default();
+
+        assert!(!engine.is_running(), "The Engine should not be running.");
+    }
 }
 
 /// Build and customize an instance of the [Engine].

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -141,6 +141,7 @@ mod wolf_engine_tests {
         let mut engine = Engine::default(); 
         let mut state = MockState::new();
         state.expect_setup().times(1).returning(|_| ());
+        engine.state_stack.push(Box::from(state), &mut engine.context);
 
         assert!(engine.is_running(), "The Engine should not be running.");
     }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -143,14 +143,14 @@ mod wolf_engine_tests {
         state.expect_setup().times(1).returning(|_| ());
         engine.state_stack.push(Box::from(state), &mut engine.context);
 
-        assert!(engine.is_running(), "The Engine should not be running.");
+        assert!(engine.is_running(), "The Engine should indicate it is running.");
     }
 
     #[test]
     fn should_not_indicate_is_running_if_no_state_is_loaded() {
         let engine = Engine::default();
 
-        assert!(!engine.is_running(), "The Engine should not be running.");
+        assert!(!engine.is_running(), "The Engine should not indicate it is running."); 
     }
 }
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -112,7 +112,8 @@ impl Engine {
     pub fn is_running(&self) -> bool {
         self.state_stack.is_not_empty()
     }
-
+    
+    /// Triggers the start of a new frame.
     pub fn start_frame() {
         puffin::GlobalProfiler::lock().new_frame()
     }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -103,29 +103,31 @@ impl Engine {
             core: Box::from(|_| {}),
         }
     }
-    
+
     /// Returns true if the engine is running.
     ///
     /// The engine is considered to be running when the following conditions are met:
     ///
     /// - There is at least one [State] on the [StateStack].
     pub fn is_running(&self) -> bool {
-        self.state_stack.is_not_empty() 
+        self.state_stack.is_not_empty()
     }
-    
+
+    pub fn start_frame() {
+        puffin::GlobalProfiler::lock().new_frame()
+    }
+
     /// Runs a complete update of all engine and game state.
     pub fn update(&mut self) {
         puffin::profile_scope!("update");
-        self
-            .scheduler
+        self.scheduler
             .update(&mut self.context, &mut self.state_stack);
     }
-    
+
     /// Renders the current frame.
     pub fn render(&mut self) {
         puffin::profile_scope!("render");
-        self
-            .scheduler
+        self.scheduler
             .render(&mut self.context, &mut self.state_stack);
     }
 }
@@ -159,19 +161,27 @@ mod wolf_engine_tests {
 
     #[test]
     fn should_indicate_is_running_if_state_is_loaded() {
-        let mut engine = Engine::default(); 
+        let mut engine = Engine::default();
         let mut state = MockState::new();
         state.expect_setup().times(1).returning(|_| ());
-        engine.state_stack.push(Box::from(state), &mut engine.context);
+        engine
+            .state_stack
+            .push(Box::from(state), &mut engine.context);
 
-        assert!(engine.is_running(), "The Engine should indicate it is running.");
+        assert!(
+            engine.is_running(),
+            "The Engine should indicate it is running."
+        );
     }
 
     #[test]
     fn should_not_indicate_is_running_if_no_state_is_loaded() {
         let engine = Engine::default();
 
-        assert!(!engine.is_running(), "The Engine should not indicate it is running."); 
+        assert!(
+            !engine.is_running(),
+            "The Engine should not indicate it is running."
+        );
     }
 }
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -112,7 +112,7 @@ impl Engine {
     pub fn is_running(&self) -> bool {
         self.state_stack.is_not_empty()
     }
-    
+
     /// Triggers the start of a new frame.
     pub fn start_frame() {
         puffin::GlobalProfiler::lock().new_frame()

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -114,7 +114,7 @@ impl Engine {
     }
 
     /// Triggers the start of a new frame.
-    pub fn start_frame() {
+    pub fn start_frame(&mut self) {
         puffin::GlobalProfiler::lock().new_frame()
     }
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -105,7 +105,7 @@ impl Engine {
     }
 
     pub fn is_running(&self) -> bool {
-        false 
+        self.state_stack.is_not_empty() 
     }
 }
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -114,12 +114,14 @@ impl Engine {
     }
 
     pub fn update(&mut self) {
+        puffin::profile_scope!("update");
         self
             .scheduler
             .update(&mut self.context, &mut self.state_stack);
     }
 
     pub fn render(&mut self) {
+        puffin::profile_scope!("render");
         self
             .scheduler
             .render(&mut self.context, &mut self.state_stack);

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -114,11 +114,15 @@ impl Engine {
     }
 
     pub fn update(&mut self) {
-
+        self
+            .scheduler
+            .profile_update(&mut self.context, &mut self.state_stack);
     }
 
     pub fn render(&mut self) {
-
+        self
+            .scheduler
+            .render(&mut self.context, &mut self.state_stack);
     }
 }
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -103,6 +103,10 @@ impl Engine {
             core: Box::from(|_| {}),
         }
     }
+
+    pub fn is_running(&self) -> bool {
+        false 
+    }
 }
 
 impl Default for Engine {

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -83,28 +83,8 @@ pub type Frames = u64;
 /// ```
 #[cfg_attr(test, automock)]
 pub trait Scheduler {
-    /// Profiles the [Scheduler::update()] method.
-    ///
-    /// **Warning:** This method is private API and SHOULD NOT be used by 3rd party code.
-    /// It is subject to change at any time without warning.
-    #[doc(hidden)]
-    fn profile_update(&mut self, context: &mut Context, state: &mut dyn State) {
-        puffin::profile_scope!("update");
-        self.update(context, state);
-    }
-
     /// Update the game state.
     fn update(&mut self, context: &mut Context, state: &mut dyn State);
-
-    /// Profiles the [Scheduler::render()] method.
-    ///
-    /// **Warning:** This method is private API and SHOULD NOT be used by 3rd party code.
-    /// It is subject to change at any time without warning.
-    #[doc(hidden)]
-    fn profile_render(&mut self, context: &mut Context, state: &mut dyn State) {
-        puffin::profile_scope!("render");
-        self.render(context, state);
-    }
 
     /// Render the game state.
     fn render(&mut self, context: &mut Context, state: &mut dyn State);

--- a/src/plugins/puffin_plugin.rs
+++ b/src/plugins/puffin_plugin.rs
@@ -20,8 +20,7 @@ impl Plugin for PuffinPlugin {
 #[cfg(feature = "http_profiling")]
 fn enable_puffin_http(mut engine_builder: EngineBuilder) -> EngineBuilder {
     let puffin_server_result = contexts::PuffinHttpContext::new();
-    if puffin_server_result.is_ok() {
-        let http_context = puffin_server_result.unwrap();
+    if let Ok(http_context) = puffin_server_result {
         log::info!("Successfully created Puffin HTTP server at: 0.0.0.0:8585");
         engine_builder = engine_builder.with_subcontext(http_context);
     } else {


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

Added some new functions to the `Engine` which wrap common, default behaviors of the engine.  This has been done to help make implementing custom core functions easier, and to reduce needless and error-prone code duplication for what should be common behaviors.  Most core function implementations will want to preserve's Wolf Engine's default behavior while integrating with 3rd party libraries, and expecting these functions to re-implement default functionality is nonsensical.  In order to solve these problems, the `Engine` now provides default implementations for it's common behaviors for core functions to as they need.

This PR closes #64.

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

<!-- Select one (Delete the rest): -->

- Minor

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Added `Engine::is_running()` method.
- [x] Added `Engine::start_frame()` method.
- [x] Added `Engine::update()` method.
- [x] Added `Engine::render()` method.
- [x] Updated `run_while_has_active_state()` to use the new methods provided by the `Engine`.
- [x] Removed `Scheduler::profile_update()` method.
- [x] Removed `Scheduler::profile_render()` method.
- [x] Made minor stylistic refactoring to `PuffinPlugin` and `PuffinHttpPlugin` as suggested by Clippy.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All compiler warnings have been resolved.
  - [x] All Clippy warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relevant examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch.
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
