### PR TITLE
Feature/plugin loader can fail

### DIFF
--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -236,7 +236,7 @@ impl EngineBuilder {
         let plugin_loader = replace(&mut self.plugin_loader, PluginLoader::new());
         match plugin_loader.load_all(self) {
             Ok(engine_builder) => Ok(engine_builder.engine),
-            Err(error_message) => Err(error_message)
+            Err(error_message) => Err(error_message),
         }
     }
 
@@ -332,15 +332,19 @@ mod engine_builder_tests {
     #[test]
     fn should_return_error_on_plugin_failure() {
         let mut plugin = MockPlugin::new();
-        plugin.expect_setup().once().returning(|engine_builder| Err(("Test Error", engine_builder)));
+        plugin
+            .expect_setup()
+            .once()
+            .returning(|engine_builder| Err(("Test Error", engine_builder)));
         plugin.expect_name().once().returning(|| "Test Plugin");
 
-        let result = EngineBuilder::new()
-            .with_plugin(Box::from(plugin))
-            .build();
+        let result = EngineBuilder::new().with_plugin(Box::from(plugin)).build();
 
         assert!(result.is_err());
-        assert_eq!(result.err().unwrap(), "Failed to load Test Plugin: Test Error");
+        assert_eq!(
+            result.err().unwrap(),
+            "Failed to load Test Plugin: Test Error"
+        );
     }
 
     #[test]

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -330,6 +330,20 @@ mod engine_builder_tests {
     }
 
     #[test]
+    fn should_return_error_on_plugin_failure() {
+        let mut plugin = MockPlugin::new();
+        plugin.expect_setup().once().returning(|engine_builder| Err(("Test Error", engine_builder)));
+        plugin.expect_name().once().returning(|| "Test Plugin");
+
+        let result = EngineBuilder::new()
+            .with_plugin(Box::from(plugin))
+            .build();
+
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap(), "Failed to load Test Plugin: Test Error");
+    }
+
+    #[test]
     fn should_add_subcontexts_to_the_context_object() {
         let mut engine_builder = EngineBuilder::new();
         let subcontext = MockSubcontext::new();

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -234,8 +234,10 @@ impl EngineBuilder {
     /// Consumes the engine builder and returns an [Engine] created from it.
     pub fn build(mut self) -> Result<Engine, String> {
         let plugin_loader = replace(&mut self.plugin_loader, PluginLoader::new());
-        let engine_builder = plugin_loader.load_all(self);
-        Ok(engine_builder.engine)
+        match plugin_loader.load_all(self) {
+            Ok(engine_builder) => Ok(engine_builder.engine),
+            Err(_) => Err("Failed to load plugin.".to_string()),
+        }
     }
 
     /// Set a custom [Scheduler] to be used.

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -236,7 +236,7 @@ impl EngineBuilder {
         let plugin_loader = replace(&mut self.plugin_loader, PluginLoader::new());
         match plugin_loader.load_all(self) {
             Ok(engine_builder) => Ok(engine_builder.engine),
-            Err(_) => Err("Failed to load plugin.".to_string()),
+            Err(error_message) => Err(error_message)
         }
     }
 

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -45,7 +45,7 @@ impl PluginLoader {
     ///
     /// Information about which plugins are being loaded, as well as their status is
     /// logged as [debug information](debug).
-    pub fn load_all(mut self, mut engine_builder: EngineBuilder) -> EngineBuilder {
+    pub fn load_all(mut self, mut engine_builder: EngineBuilder) -> Result<EngineBuilder, ()> {
         for plugin in self.plugins.iter_mut() {
             debug!("Now loading plugin: {}", plugin.name());
             engine_builder = match plugin.setup(engine_builder) {

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -104,7 +104,7 @@ mod plugin_loader_tests {
         let mut plugin = MockPlugin::new(); 
         plugin.expect_setup()
             .once()
-            .returning(|engine_builder| Err(("Test error", engine_builder)));
+            .returning(|engine_builder| Err(("Test Error", engine_builder)));
         plugin.expect_name().once().returning(|| "Test Plugin");
         plugin_loader.add(Box::from(plugin));
 

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -105,6 +105,7 @@ mod plugin_loader_tests {
         plugin.expect_setup()
             .once()
             .returning(|engine_builder| Err(("Test error", engine_builder)));
+        plugin.expect_name().once().returning(|| "Test Plugin");
         plugin_loader.add(Box::from(plugin));
 
         let loader_result = plugin_loader.load_all(EngineBuilder::new());

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -95,6 +95,12 @@ mod plugin_loader_tests {
         let _engine_builder = plugin_loader.load_all(EngineBuilder::new()).unwrap();
     }
 
+    fn mock_plugin() -> MockPlugin {
+        let mut plugin = MockPlugin::new();
+        plugin.expect_setup().once().returning(Ok);
+        plugin
+    }
+
     #[test]
     fn should_return_error_on_plugin_failure() {
         let mut plugin_loader = PluginLoader::new();
@@ -107,12 +113,6 @@ mod plugin_loader_tests {
         let loader_result = plugin_loader.load_all(EngineBuilder::new());
     
         assert!(loader_result.is_err());
-    }
-
-    fn mock_plugin() -> MockPlugin {
-        let mut plugin = MockPlugin::new();
-        plugin.expect_setup().once().returning(Ok);
-        plugin
     }
 
     #[test]

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -110,7 +110,7 @@ mod plugin_loader_tests {
         let loader_result = plugin_loader.load_all(EngineBuilder::new());
     
         assert!(loader_result.is_err());
-        assert_eq!(loader_result.unwrap_err(), "Failed to load Test Plugin: Test Error");
+        assert_eq!(loader_result.err().unwrap(), "Failed to load Test Plugin: Test Error");
     }
 
     #[test]

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -53,7 +53,7 @@ impl PluginLoader {
                     debug!("Successfully loaded plugin: {}", plugin.name());
                     engine_builder
                 }
-                Err((error_message, engine_builder)) => {
+                Err((error_message, _)) => {
                     error!(
                         "Failed to load plugin: {}: {}",
                         plugin.name(),
@@ -93,6 +93,20 @@ mod plugin_loader_tests {
         plugin_loader.add(Box::from(mock_plugin()));
 
         let _engine_builder = plugin_loader.load_all(EngineBuilder::new()).unwrap();
+    }
+
+    #[test]
+    fn should_return_error_on_plugin_failure() {
+        let mut plugin_loader = PluginLoader::new();
+        let mut plugin = MockPlugin::new(); 
+        plugin.expect_setup()
+            .once()
+            .returning(|engine_builder| Err(("Test error", engine_builder)));
+        plugin_loader.add(Box::from(plugin));
+
+        let loader_result = plugin_loader.load_all(EngineBuilder::new());
+    
+        assert!(loader_result.is_err());
     }
 
     fn mock_plugin() -> MockPlugin {

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -113,6 +113,7 @@ mod plugin_loader_tests {
         let loader_result = plugin_loader.load_all(EngineBuilder::new());
     
         assert!(loader_result.is_err());
+        assert_eq!(loader_result.unwrap_err(), "Failed to load Test Plugin: Test Error");
     }
 
     #[test]

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -45,7 +45,7 @@ impl PluginLoader {
     ///
     /// Information about which plugins are being loaded, as well as their status is
     /// logged as [debug information](debug).
-    pub fn load_all(mut self, mut engine_builder: EngineBuilder) -> Result<EngineBuilder, String>{
+    pub fn load_all(mut self, mut engine_builder: EngineBuilder) -> Result<EngineBuilder, String> {
         for plugin in self.plugins.iter_mut() {
             debug!("Now loading plugin: {}", plugin.name());
             engine_builder = match plugin.setup(engine_builder) {
@@ -56,7 +56,7 @@ impl PluginLoader {
                 Err((error_message, _)) => {
                     let error = format!("Failed to load {}: {}", plugin.name(), error_message);
                     error!("{}", error);
-                    return Err(error) 
+                    return Err(error);
                 }
             }
         }
@@ -101,17 +101,21 @@ mod plugin_loader_tests {
     #[test]
     fn should_return_error_on_plugin_failure() {
         let mut plugin_loader = PluginLoader::new();
-        let mut plugin = MockPlugin::new(); 
-        plugin.expect_setup()
+        let mut plugin = MockPlugin::new();
+        plugin
+            .expect_setup()
             .once()
             .returning(|engine_builder| Err(("Test Error", engine_builder)));
         plugin.expect_name().once().returning(|| "Test Plugin");
         plugin_loader.add(Box::from(plugin));
 
         let loader_result = plugin_loader.load_all(EngineBuilder::new());
-    
+
         assert!(loader_result.is_err());
-        assert_eq!(loader_result.err().unwrap(), "Failed to load Test Plugin: Test Error");
+        assert_eq!(
+            loader_result.err().unwrap(),
+            "Failed to load Test Plugin: Test Error"
+        );
     }
 
     #[test]

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -45,7 +45,7 @@ impl PluginLoader {
     ///
     /// Information about which plugins are being loaded, as well as their status is
     /// logged as [debug information](debug).
-    pub fn load_all(mut self, mut engine_builder: EngineBuilder) -> Result<EngineBuilder, ()> {
+    pub fn load_all(mut self, mut engine_builder: EngineBuilder) -> Result<EngineBuilder, String>{
         for plugin in self.plugins.iter_mut() {
             debug!("Now loading plugin: {}", plugin.name());
             engine_builder = match plugin.setup(engine_builder) {
@@ -54,12 +54,9 @@ impl PluginLoader {
                     engine_builder
                 }
                 Err((error_message, _)) => {
-                    error!(
-                        "Failed to load plugin: {}: {}",
-                        plugin.name(),
-                        error_message
-                    );
-                    return Err(()) 
+                    let error = format!("Failed to load {}: {}", plugin.name(), error_message);
+                    error!("{}", error);
+                    return Err(error) 
                 }
             }
         }

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -92,7 +92,7 @@ mod plugin_loader_tests {
         plugin_loader.add(Box::from(mock_plugin()));
         plugin_loader.add(Box::from(mock_plugin()));
 
-        let _engine_builder = plugin_loader.load_all(EngineBuilder::new());
+        let _engine_builder = plugin_loader.load_all(EngineBuilder::new()).unwrap();
     }
 
     fn mock_plugin() -> MockPlugin {

--- a/src/core/plugin/plugin_loader.rs
+++ b/src/core/plugin/plugin_loader.rs
@@ -59,11 +59,11 @@ impl PluginLoader {
                         plugin.name(),
                         error_message
                     );
-                    engine_builder
+                    return Err(()) 
                 }
             }
         }
-        engine_builder
+        Ok(engine_builder)
     }
 }
 


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

This PR updates plugin loading so now a `Plugin` failing to load will now cause `EngineBuilder::build()` to return an `Err`.  In nearly all cases, a plugin failing to load means the game will not function correctly, so it is best to prevent the engine from running.

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

<!-- Select one (Delete the rest): -->

- Major

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Changed return type of `PluginLoader::load_all()` to a `Result`.
- [x] Updated `EngineBuilder::build()` so an `Err` from `PluginLoader::load_all()` cause `build()` to also return an `Err`.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All compiler warnings have been resolved.
  - [x] All Clippy warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relevant examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch (`fetch origin/main && merge origin/main`.)
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
