### PR TITLE
Refactor/cleanup useless types

### DIFF
--- a/examples/custom_subcontexts.rs
+++ b/examples/custom_subcontexts.rs
@@ -41,7 +41,7 @@ impl State for MyState {
         }
     }
 
-    fn render(&mut self, context: &mut Context) -> RenderResult {
+    fn render(&mut self, context: &mut Context) {
         let custom_context = context.borrow::<CustomContext>().unwrap();
         info!("{}: {}", custom_context.message, custom_context.count);
     }

--- a/examples/multiple_states.rs
+++ b/examples/multiple_states.rs
@@ -41,7 +41,7 @@ impl State for MainState {
         );
     }
 
-    fn render(&mut self, _context: &mut Context) -> RenderResult {}
+    fn render(&mut self, _context: &mut Context) {}
 }
 
 pub struct SubState {
@@ -69,7 +69,7 @@ impl State for SubState {
         }
     }
 
-    fn render(&mut self, _context: &mut Context) -> RenderResult {
+    fn render(&mut self, _context: &mut Context) {
         info!("[SubState] {}", self.message);
         self.displayed_message = true;
         thread::sleep(Duration::from_millis(32));

--- a/examples/plugins.rs
+++ b/examples/plugins.rs
@@ -61,5 +61,5 @@ impl State for GameState {
         Some(Transition::Clean)
     }
 
-    fn render(&mut self, _context: &mut Context) -> RenderResult {}
+    fn render(&mut self, _context: &mut Context) {}
 }

--- a/examples/profiling.rs
+++ b/examples/profiling.rs
@@ -34,7 +34,7 @@ impl State for GameState {
         None
     }
 
-    fn render(&mut self, _context: &mut Context) { 
+    fn render(&mut self, _context: &mut Context) {
         // Allow Puffin to set profiler scope name based on the function name.
         profile_function!();
         sleep(Duration::from_millis(16)); // 60 fps.

--- a/examples/profiling.rs
+++ b/examples/profiling.rs
@@ -34,7 +34,7 @@ impl State for GameState {
         None
     }
 
-    fn render(&mut self, _context: &mut Context) -> RenderResult {
+    fn render(&mut self, _context: &mut Context) { 
         // Allow Puffin to set profiler scope name based on the function name.
         profile_function!();
         sleep(Duration::from_millis(16)); // 60 fps.

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -52,7 +52,7 @@ impl State for FizzBuzzState {
         }
     }
 
-    fn render(&mut self, _context: &mut Context) -> RenderResult {
+    fn render(&mut self, _context: &mut Context) {
         // Nothing to render for this example.
     }
 }

--- a/examples/state_basics.rs
+++ b/examples/state_basics.rs
@@ -40,7 +40,7 @@ impl State for MyState {
         }
     }
 
-    fn render(&mut self, _context: &mut Context) -> RenderResult {
+    fn render(&mut self, _context: &mut Context) {
         self.frames += 1;
         info!("{} {}", self.message, self.frames);
         thread::sleep(Duration::from_millis(32));

--- a/src/contexts/scheduler_context.rs
+++ b/src/contexts/scheduler_context.rs
@@ -73,8 +73,8 @@ use crate::Subcontext;
 /// ```
 #[derive(Default)]
 pub struct SchedulerContext {
-    ticks: usize,
-    frames: usize,
+    ticks: u64,
+    frames: u64,
 }
 
 impl SchedulerContext {
@@ -92,7 +92,7 @@ impl SchedulerContext {
     }
 
     /// Access the current number of counted ticks.
-    pub fn ticks(&self) -> usize {
+    pub fn ticks(&self) -> u64 {
         self.ticks
     }
 
@@ -105,7 +105,7 @@ impl SchedulerContext {
     }
 
     /// Access the current number of counted frames.
-    pub fn frames(&self) -> usize {
+    pub fn frames(&self) -> u64 {
         self.frames
     }
 }

--- a/src/contexts/scheduler_context.rs
+++ b/src/contexts/scheduler_context.rs
@@ -1,4 +1,4 @@
-use crate::{Frames, Subcontext, Ticks};
+use crate::Subcontext;
 
 /// Provides a way for the active [Scheduler](crate::Scheduler) to report basic data.  
 ///
@@ -73,8 +73,8 @@ use crate::{Frames, Subcontext, Ticks};
 /// ```
 #[derive(Default)]
 pub struct SchedulerContext {
-    ticks: Ticks,
-    frames: Frames,
+    ticks: usize,
+    frames: usize,
 }
 
 impl SchedulerContext {
@@ -92,7 +92,7 @@ impl SchedulerContext {
     }
 
     /// Access the current number of counted ticks.
-    pub fn ticks(&self) -> Ticks {
+    pub fn ticks(&self) -> usize {
         self.ticks
     }
 
@@ -105,7 +105,7 @@ impl SchedulerContext {
     }
 
     /// Access the current number of counted frames.
-    pub fn frames(&self) -> Frames {
+    pub fn frames(&self) -> usize {
         self.frames
     }
 }

--- a/src/contexts/scheduler_context.rs
+++ b/src/contexts/scheduler_context.rs
@@ -3,7 +3,7 @@ use crate::Subcontext;
 /// Provides a way for the active [Scheduler](crate::Scheduler) to report basic data.  
 ///
 /// The scheduler context allows the [Scheduler](crate::Scheduler) to update information
-/// such as number of [Ticks] and [Frames] that have been run.  This information can
+/// such as number of ticks and frames  that have been run.  This information can
 /// also be accessed by the rest of the engine.
 ///
 /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!         None
 //!     }
 //!
-//!     fn render(&mut self, context: &mut Context) -> RenderResult {
+//!     fn render(&mut self, context: &mut Context) {
 //!         // Render your game here.
 //!     }
 //! }
@@ -76,7 +76,7 @@
 //!         None
 //!     }
 //!
-//!     fn render(&mut self, _context: &mut Context) -> RenderResult {}
+//!     fn render(&mut self, _context: &mut Context) {}
 //! }
 //! ```
 //!
@@ -121,7 +121,7 @@
 //!         }
 //!     }
 //!
-//!     fn render(&mut self, _context: &mut Context) -> RenderResult {}
+//!     fn render(&mut self, _context: &mut Context) {}
 //! }
 //!
 //! pub struct StateB {
@@ -149,7 +149,7 @@
 //!         }
 //!     }
 //!
-//!     fn render(&mut self, _context: &mut Context) -> RenderResult {}
+//!     fn render(&mut self, _context: &mut Context) {}
 //! }
 //! ```
 //! It is important to note that only the top [State] can control the [StateStack], as

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -5,12 +5,6 @@ use crate::{Context, State};
 #[cfg(test)]
 use mockall::automock;
 
-/// Represents the number of ticks the engine has run.
-pub type Ticks = u64;
-
-/// Represents the number of frames the engine has rendered.
-pub type Frames = u64;
-
 /// Controls how the game is run.
 ///
 /// The scheduler is responsible for determining if or when the game should be updated

--- a/src/state.rs
+++ b/src/state.rs
@@ -56,7 +56,7 @@ pub enum Transition {
 ///         }
 ///     }
 ///
-///     fn render(&mut self, _context: &mut Context) -> RenderResult {
+///     fn render(&mut self, _context: &mut Context) {
 ///         // Render logic
 ///     }
 /// }

--- a/src/state.rs
+++ b/src/state.rs
@@ -144,7 +144,7 @@ pub trait State {
     ///
     /// - The [Engine] requests a frame to render,
     /// - and the state is not the topmost state on the [StateStack].
-    fn background_render(&mut self, _context: &mut Context) -> RenderResult {}
+    fn background_render(&mut self, _context: &mut Context) {}
 }
 
 /// A no-op state that will close immediately.
@@ -159,5 +159,5 @@ impl State for EmptyState {
         Some(Transition::Clean)
     }
 
-    fn render(&mut self, _context: &mut Context) -> RenderResult {}
+    fn render(&mut self, _context: &mut Context)  {} 
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -132,7 +132,7 @@ pub trait State {
     ///
     /// - The [Engine] requests a frame to render,
     /// - and the state is the topmost state on the [StateStack].
-    fn render(&mut self, context: &mut Context); 
+    fn render(&mut self, context: &mut Context);
 
     /// Render the game state in the background.
     ///
@@ -159,5 +159,5 @@ impl State for EmptyState {
         Some(Transition::Clean)
     }
 
-    fn render(&mut self, _context: &mut Context)  {} 
+    fn render(&mut self, _context: &mut Context) {}
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -132,7 +132,7 @@ pub trait State {
     ///
     /// - The [Engine] requests a frame to render,
     /// - and the state is the topmost state on the [StateStack].
-    fn render(&mut self, context: &mut Context) -> RenderResult;
+    fn render(&mut self, context: &mut Context); 
 
     /// Render the game state in the background.
     ///

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,9 +3,6 @@ use crate::*;
 #[cfg(test)]
 use mockall::automock;
 
-/// A currently unused return type for [State]'s render method.
-pub type RenderResult = ();
-
 /// Indicates if a [Transition] should be performed.
 pub type OptionalTransition = Option<Transition>;
 

--- a/src/state_stack.rs
+++ b/src/state_stack.rs
@@ -176,7 +176,7 @@ impl State for StateStack {
         None
     }
 
-    fn render(&mut self, context: &mut Context) -> RenderResult {
+    fn render(&mut self, context: &mut Context) {
         self.take_background_states()
             .for_each(|state| state.background_render(context));
         if let Some(state) = self.active_mut() {

--- a/src/state_stack.rs
+++ b/src/state_stack.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, iter::Take, slice::IterMut};
 
-use crate::{Context, OptionalTransition, RenderResult, State, Transition};
+use crate::{Context, OptionalTransition, State, Transition};
 /// Provides a stack for storing, managing, and running multiple [State] objects.
 ///
 /// The state stack acts as a common interface through which numerous [State]s can be run


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

This PR removes placeholder types (`RenderResult`,) and types that are better converted to a primitives (`Frames` and `Ticks`).   There used to be plan for these types when they were introduced, but at this point they are a bit pointless. 

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

<!-- Select one (Delete the rest): -->

- Major

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Removed `RenderResult` type.
- [x] Removed `Frames` type.
- [x] Removed `Ticks` type. 

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [ ] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [ ] All compiler warnings have been resolved.
  - [ ] All Clippy warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relevant examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [ ] Merge
  - [x] The feature branch has been brought up to date with the main branch (`fetch origin/main && merge origin/main`.)
  - [ ] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
