### PR TITLE
Refactor/rename transition types

### DIFF
--- a/examples/custom_subcontexts.rs
+++ b/examples/custom_subcontexts.rs
@@ -31,10 +31,10 @@ impl Subcontext for CustomContext {}
 pub struct MyState;
 
 impl State for MyState {
-    fn update(&mut self, context: &mut Context) -> OptionalTransition {
+    fn update(&mut self, context: &mut Context) -> Transition {
         let mut custom_context = context.borrow_mut::<CustomContext>().unwrap();
         if custom_context.count == 10 {
-            Some(Transition::Clean)
+            Some(TransitionType::Clean)
         } else {
             custom_context.count += 1;
             None

--- a/examples/multiple_states.rs
+++ b/examples/multiple_states.rs
@@ -23,15 +23,15 @@ impl MainState {
 }
 
 impl State for MainState {
-    fn update(&mut self, _context: &mut Context) -> OptionalTransition {
+    fn update(&mut self, _context: &mut Context) -> Transition {
         if self.number == 10 {
             debug!("[MainState] All 10 messages displayed, quitting!");
-            Some(Transition::Clean)
+            Some(TransitionType::Clean)
         } else {
             debug!("[MainState] Pushing new sub-state to the stack.");
             self.number += 1;
             let sub_state = SubState::new(format!("Hello, World! {}", self.number));
-            Some(Transition::Push(Box::from(sub_state)))
+            Some(TransitionType::Push(Box::from(sub_state)))
         }
     }
 
@@ -59,10 +59,10 @@ impl SubState {
 }
 
 impl State for SubState {
-    fn update(&mut self, _context: &mut Context) -> OptionalTransition {
+    fn update(&mut self, _context: &mut Context) -> Transition {
         if self.displayed_message {
             debug!("[SubState] The message was displayed.  Returning control to the main state.");
-            Some(Transition::Pop)
+            Some(TransitionType::Pop)
         } else {
             debug!("[SubState] The message was not displayed.  Waiting for the next frame.");
             None

--- a/examples/plugins.rs
+++ b/examples/plugins.rs
@@ -55,10 +55,10 @@ impl Subcontext for MessageContext {}
 pub struct GameState;
 
 impl State for GameState {
-    fn update(&mut self, context: &mut Context) -> OptionalTransition {
+    fn update(&mut self, context: &mut Context) -> Transition {
         let message = context.borrow::<MessageContext>().unwrap();
         info!("{}", message.message);
-        Some(Transition::Clean)
+        Some(TransitionType::Clean)
     }
 
     fn render(&mut self, _context: &mut Context) {}

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -41,10 +41,10 @@ impl FizzBuzzState {
 }
 
 impl State for FizzBuzzState {
-    fn update(&mut self, _context: &mut Context) -> OptionalTransition {
+    fn update(&mut self, _context: &mut Context) -> Transition {
         if self.number == 100 {
             info!("Goodbye!");
-            Some(Transition::Clean) // Tell the engine we want to quit.
+            Some(TransitionType::Clean) // Tell the engine we want to quit.
         } else {
             self.number += 1;
             info!("{}", Self::fizz_buzz(self.number));

--- a/examples/state_basics.rs
+++ b/examples/state_basics.rs
@@ -29,10 +29,10 @@ impl MyState {
 }
 
 impl State for MyState {
-    fn update(&mut self, _context: &mut Context) -> OptionalTransition {
+    fn update(&mut self, _context: &mut Context) -> Transition {
         if self.frames == 10 {
             info!("Goodbye!");
-            Some(Transition::Clean)
+            Some(TransitionType::Clean)
         } else {
             self.updates += 1;
             debug!("Update: {}", self.updates);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -144,7 +144,7 @@ impl Default for Engine {
 #[cfg(test)]
 mod wolf_engine_tests {
     use crate::contexts::EngineContext;
-    use crate::{MockState, Transition};
+    use crate::{MockState, TransitionType};
 
     use super::*;
 
@@ -156,7 +156,7 @@ mod wolf_engine_tests {
         state
             .expect_update()
             .times(1..)
-            .returning(|_| Some(Transition::Clean));
+            .returning(|_| Some(TransitionType::Clean));
         state.expect_render().times(1..).returning(|_| ());
         state.expect_shutdown().times(1).returning(|_| ());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! pub struct MyGameState;
 //!
 //! impl State for MyGameState {
-//!     fn update(&mut self, context: &mut Context) -> OptionalTransition {
+//!     fn update(&mut self, context: &mut Context) -> Transition {
 //!         // Update your game here.
 //! #       context.quit();
 //!         None
@@ -71,7 +71,7 @@
 //! }
 //!
 //! impl State for MyState {
-//!     fn update(&mut self, _context: &mut Context) -> OptionalTransition {
+//!     fn update(&mut self, _context: &mut Context) -> Transition {
 //!         self.counter += 1;
 //!         None
 //!     }
@@ -97,7 +97,7 @@
 //!
 //! #### Changing States
 //!
-//! A [Transition] is ([Optionally](OptionalTransition)) returned by [State::update()] and is used
+//! A [Transition] is ([Optionally](Transition)) returned by [State::update()] and is used
 //! to control the [StateStack] by pushing and popping [States](State) on the [StateStack].
 //!
 //! ```
@@ -108,16 +108,16 @@
 //! }
 //!
 //! impl State for StateA {
-//!     fn update(&mut self, _context: &mut Context) -> OptionalTransition {
+//!     fn update(&mut self, _context: &mut Context) -> Transition {
 //!         if self.counter < 10 {
 //!             println!("Hello from State A!");
 //!             // Increment the counter and push State B to the top of the stack.
 //!             self.counter += 1;
-//!             Some(Transition::Push(Box::from(StateB::new())))
+//!             Some(TransitionType::Push(Box::from(StateB::new())))
 //!         } else {
 //!             // Once the counter reaches 10, pop all states off the stack.
 //!             // An empty state stack will trigger an engine shutdown.
-//!             Some(Transition::Clean)
+//!             Some(TransitionType::Clean)
 //!         }
 //!     }
 //!
@@ -135,7 +135,7 @@
 //! # }
 //! #
 //! impl State for StateB {
-//!     fn update(&mut self, _context: &mut Context) -> OptionalTransition {
+//!     fn update(&mut self, _context: &mut Context) -> Transition {
 //!         if self.counter < 3 {
 //!             println!("Hello from State B!");
 //!             // Increment the counter then return no transition.
@@ -145,7 +145,7 @@
 //!         } else {
 //!             // Once the counter reaches 3, pop this state off the stack.
 //!             // This will return control back to the State A.
-//!             Some(Transition::Pop)
+//!             Some(TransitionType::Pop)
 //!         }
 //!     }
 //!

--- a/src/state.rs
+++ b/src/state.rs
@@ -52,7 +52,7 @@ pub enum TransitionType {
 ///             None // Don't transition, just keep running
 ///         } else {
 ///             // We've counted to 10, lets tell the engine to quit
-///             Some(TranstionType::Clean)
+///             Some(TransitionType::Clean)
 ///         }
 ///     }
 ///

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,11 +4,11 @@ use crate::*;
 use mockall::automock;
 
 /// Indicates if a [Transition] should be performed.
-pub type OptionalTransition = Option<Transition>;
+pub type OptionalTransition = Option<TransitionType>;
 
 /// Indicates the type of [Transition] the [StateStack](crate::StateStack) should
 /// perform.
-pub enum Transition {
+pub enum TransitionType {
     /// Push a new [State] to the top of the stack.
     Push(Box<dyn State>),
 
@@ -156,7 +156,7 @@ pub struct EmptyState;
 
 impl State for EmptyState {
     fn update(&mut self, _context: &mut Context) -> OptionalTransition {
-        Some(Transition::Clean)
+        Some(TransitionType::Clean)
     }
 
     fn render(&mut self, _context: &mut Context) {}

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,7 +3,7 @@ use crate::*;
 #[cfg(test)]
 use mockall::automock;
 
-/// An [Option]al, [TransitionType] used to send instructions to the [StateStack](crate::StateStack).
+/// An [Optional](Option), [TransitionType] used to send instructions to the [StateStack](crate::StateStack).
 pub type Transition = Option<TransitionType>;
 
 /// Represents a state change for the [StateStack](crate::StateStack) to perform.

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,7 +3,7 @@ use crate::*;
 #[cfg(test)]
 use mockall::automock;
 
-/// An [Optional], [TransitionType] used to send instructions to the [StateStack](crate::StateStack).
+/// An [Option]al, [TransitionType] used to send instructions to the [StateStack](crate::StateStack).
 pub type Transition = Option<TransitionType>;
 
 /// Represents a state change for the [StateStack](crate::StateStack) to perform.

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,11 +3,10 @@ use crate::*;
 #[cfg(test)]
 use mockall::automock;
 
-/// Indicates if a [Transition] should be performed.
+/// An [Optional], [TransitionType] used to send instructions to the [StateStack](crate::StateStack).
 pub type Transition = Option<TransitionType>;
 
-/// Indicates the type of [Transition] the [StateStack](crate::StateStack) should
-/// perform.
+/// Represents a state change for the [StateStack](crate::StateStack) to perform.
 pub enum TransitionType {
     /// Push a new [State] to the top of the stack.
     Push(Box<dyn State>),

--- a/src/state.rs
+++ b/src/state.rs
@@ -32,7 +32,7 @@ pub enum TransitionType {
 /// By default, States are controlled by the [StateStack].  The [StateStack] allows States
 /// to be stacked on top of each other and ran all together, resulting in a "layered"
 /// behavior.  Active States can also control the [StateStack] by returning an
-/// [OptionalTransition] from the [State::update()] method.  
+/// [Transition] from the [State::update()] method.  
 ///
 /// See the [StateStack] docs for more information.
 ///
@@ -46,13 +46,13 @@ pub enum TransitionType {
 /// }
 ///
 /// impl State for MyGame {
-///     fn update(&mut self, _context: &mut Context) -> OptionalTransition {
+///     fn update(&mut self, _context: &mut Context) -> Transition {
 ///         if self.number < 10 {
 ///             self.number += 1;
 ///             None // Don't transition, just keep running
 ///         } else {
 ///             // We've counted to 10, lets tell the engine to quit
-///             Some(Transition::Clean)
+///             Some(TranstionType::Clean)
 ///         }
 ///     }
 ///

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,7 +4,7 @@ use crate::*;
 use mockall::automock;
 
 /// Indicates if a [Transition] should be performed.
-pub type OptionalTransition = Option<TransitionType>;
+pub type Transition = Option<TransitionType>;
 
 /// Indicates the type of [Transition] the [StateStack](crate::StateStack) should
 /// perform.
@@ -111,7 +111,7 @@ pub trait State {
     ///
     /// - The [Engine] requests a tick to run,
     /// - and the state is the topmost state on the [StateStack].
-    fn update(&mut self, context: &mut Context) -> OptionalTransition;
+    fn update(&mut self, context: &mut Context) -> Transition;
 
     /// Update the game state in the background.
     ///
@@ -155,7 +155,7 @@ pub trait State {
 pub struct EmptyState;
 
 impl State for EmptyState {
-    fn update(&mut self, _context: &mut Context) -> OptionalTransition {
+    fn update(&mut self, _context: &mut Context) -> Transition {
         Some(TransitionType::Clean)
     }
 

--- a/src/state_stack.rs
+++ b/src/state_stack.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, iter::Take, slice::IterMut};
 
-use crate::{Context, Transition, State, TransitionType};
+use crate::{Context, State, Transition, TransitionType};
 /// Provides a stack for storing, managing, and running multiple [State] objects.
 ///
 /// The state stack acts as a common interface through which numerous [State]s can be run


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

This PR renames `OptionalTransitoin` and `Transition` to give them (hopefully) better and more descriptive names.

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

<!-- Select one (Delete the rest): -->

- Major

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Renamed `OptionalTransition` to `Transition.
- [x] Renamed `Transition` to `TransitionType`.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All compiler warnings have been resolved.
  - [x] All Clippy warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relevant examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch (`fetch origin/main && merge origin/main`.)
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
