### PR TITLE
Feature/window api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wolf_engine"
 description = "A game framework with a focus on flexibility and ease of use."
-version = "0.25.0"
+version = "0.26.0"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -11,9 +11,9 @@ keywords = ["wolf-engine", "game", "gamedev"]
 categories = ["game-development", "game-engines"]
 
 [dependencies]
-wolf_engine_core = {path = "wolf_engine_core", version = "0.25.0"}
-wolf_engine_framework = {path = "wolf_engine_framework", version = "0.25.0", optional = true}
-wolf_engine_window = {path = "wolf_engine_window", version = "0.25.0", optional = true}
+wolf_engine_core = {path = "wolf_engine_core", version = "0.26.0"}
+wolf_engine_framework = {path = "wolf_engine_framework", version = "0.26.0", optional = true}
+wolf_engine_window = {path = "wolf_engine_window", version = "0.26.0", optional = true}
 
 [dev-dependencies]
 log = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! A simple, flexible, and easy to use game framework.
 //!
 //! # Features
-//! 
+//!
 //! - `framework`: Enables the high-level, "batteries included" framework.
 //! - `logging`: Enables the built-in logging framework.
 //! - `serde`: Enables serde support for some types.
@@ -68,7 +68,7 @@ pub use wolf_engine_core::logging;
 
 #[cfg(feature = "window")]
 pub mod window {
-    //! Provides a high-level, back-end agnostic window API. 
+    //! Provides a high-level, back-end agnostic window API.
     pub use wolf_engine_window::*;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! # Features
 //! 
+//! - `framework`: Enables the high-level, "batteries included" framework.
 //! - `logging`: Enables the built-in logging framework.
 //! - `serde`: Enables serde support for some types.
 //! - `window`: Enables Wolf Engine's window API.
@@ -57,11 +58,21 @@
 pub use wolf_engine_core::*;
 
 #[cfg(feature = "framework")]
-#[doc(hidden)]
-pub use wolf_engine_framework as framework;
+pub mod framework {
+    //! Provides a high-level, "batteries-included" framework.
+    //!
+    //! [See more](wolf_engine_framework).
+    pub use wolf_engine_framework::*;
+}
 
 #[cfg(feature = "logging")]
 pub use wolf_engine_core::logging;
+
+#[cfg(feature = "window")]
+pub mod window {
+    //! Provides a high-level, back-end agnostic window API. 
+    pub use wolf_engine_window::*;
+}
 
 #[doc(hidden)]
 pub mod prelude {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! # Getting Started
 //!
-//! To use the latest release:
+//! To use the latest release version:
 //!
 //! ```ignore
 //! [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 //! A simple, flexible, and easy to use game framework.
 //!
 //! # Features
-//!
+//! 
 //! - `logging`: Enables the built-in logging framework.
+//! - `serde`: Enables serde support for some types.
+//! - `window`: Enables Wolf Engine's window API.
 //!
 //! # Getting Started
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```ignore
 //! [dependencies]
-//! wolf_engine = "0.24"
+//! wolf_engine = "*"
 //! ```
 //!
 //! To use the latest development version:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,6 @@ pub use wolf_engine_core::*;
 #[cfg(feature = "framework")]
 pub mod framework {
     //! Provides a high-level, "batteries-included" framework.
-    //!
-    //! [See more](wolf_engine_framework).
     pub use wolf_engine_framework::*;
 }
 

--- a/wolf_engine_core/Cargo.toml
+++ b/wolf_engine_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wolf_engine_core"
 description = "A highly-portable core providing just the basic types, tools, and functions for Wolf Engine."
-version = "0.25.0"
+version = "0.26.0"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/wolf_engine_core/src/engine.rs
+++ b/wolf_engine_core/src/engine.rs
@@ -199,6 +199,7 @@ mod engine_tests {
                     engine.update();
                     engine.render();
                 }
+                _ => (),
             }
         }
 

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -1,3 +1,4 @@
+/// Provides the events used by the window API.
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum WindowEvent {}
@@ -17,6 +18,7 @@ pub enum Event {
     /// `EventsCleared` should be emitted only after all other events have been processed.
     EventsCleared,
     
+    /// Contains [`WindowEvent`] emitted by the window system.
     WindowEvent(WindowEvent),
 }
 

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -7,7 +7,6 @@ pub enum WindowEvent {}
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Event {
-
     /// Emitted when the engine should quit.
     Quit,
 

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -18,7 +18,7 @@ pub enum Event {
     /// `EventsCleared` should be emitted only after all other events have been processed.
     EventsCleared,
     
-    /// Contains [`WindowEvent`] emitted by the window system.
+    /// A [`WindowEvent`] emitted by the window system.
     WindowEvent(WindowEvent),
 }
 

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -7,17 +7,21 @@ pub enum WindowEvent {}
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Event {
+
     /// Emitted when the engine should quit.
     Quit,
+
     /// Indicates the engine should update game logic.
     Update,
+
     /// Indicates the engine should render the game.
     Render,
+
     /// Indicates the end of a frame.
     ///
     /// `EventsCleared` should be emitted only after all other events have been processed.
     EventsCleared,
-    
+
     /// A [`WindowEvent`] emitted by the window system.
     WindowEvent(WindowEvent),
 }

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -1,3 +1,7 @@
+#[non_exhaustive]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum WindowEvent {}
+
 /// Provides the main events used by the [`Engine`](crate::Engine).
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -12,6 +16,8 @@ pub enum Event {
     ///
     /// `EventsCleared` should be emitted only after all other events have been processed.
     EventsCleared,
+    
+    WindowEvent(WindowEvent),
 }
 
 #[cfg(test)]

--- a/wolf_engine_framework/Cargo.toml
+++ b/wolf_engine_framework/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wolf_engine_framework"
 description = "A complete, \"batteries-included\" framework for Wolf Engine."
-version = "0.25.0"
+version = "0.26.0"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ categories = ["game-development", "game-engines"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wolf_engine_core = {path = "../wolf_engine_core", version = "0.25.0"}
+wolf_engine_core = {path = "../wolf_engine_core", version = "0.26.0"}
 log = "0.4"
 
 [dev-dependencies]

--- a/wolf_engine_window/Cargo.toml
+++ b/wolf_engine_window/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["wolf-engine", "game", "gamedev", "gui"]
 categories = ["game-development", "game-engines", "gui"]
 
 [dependencies]
+raw-window-handle = "0.5"
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 
 [dev-dependencies]

--- a/wolf_engine_window/Cargo.toml
+++ b/wolf_engine_window/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolf_engine_window"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["AlexiWolf <alexiwolf@pm.me>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -10,6 +10,7 @@ keywords = ["wolf-engine", "game", "gamedev", "gui"]
 categories = ["game-development", "game-engines", "gui"]
 
 [dependencies]
+wolf_engine_core = {path = "../wolf_engine_core", version = "0.26.0"}
 raw-window-handle = "0.5"
 lazy_static = "1.4"
 

--- a/wolf_engine_window/Cargo.toml
+++ b/wolf_engine_window/Cargo.toml
@@ -11,6 +11,8 @@ categories = ["game-development", "game-engines", "gui"]
 
 [dependencies]
 raw-window-handle = "0.5"
+lazy_static = "1.4"
+
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 
 [dev-dependencies]

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -1,7 +1,7 @@
 //! Provides a high-level, back-end agnostic window API for [Wolf
 //! Engine](https://docs.rs/wolf_engine/latest).
 //!
-//! See [wolf_engine::window](https://docs.rs/wolf_engine/latest/wolf_engine/window/index.html/) 
+//! See [wolf_engine::window](https://docs.rs/wolf_engine/latest/wolf_engine/window/index.html/)
 //! for more details.
 
 mod window;

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -38,6 +38,13 @@ mod window_dimensions_tests {
         assert_eq!(dimensions.height, 600);
     }
 
+    #[test]
+    fn should_convert_from_tuple() {
+        let dimensions: WindowDimensions = (800, 600).into();
+        assert_eq!(dimensions.width, 800);
+        assert_eq!(dimensions.height, 600);
+    }
+
     #[cfg(feature = "serde")]
     #[test]
     fn should_implement_deserialize() {

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -46,14 +46,15 @@ mod window_dimensions_tests {
         height = 600
         "#;
         let dimensions: WindowDimensions = toml::from_str(toml_str).unwrap();
-        assert_eq!(window_settings.title, "Hello, world");
+        assert_eq!(dimensions.width, 800);
+        assert_eq!(dimensions.height, 600);
     }
 
     #[cfg(feature = "serde")]
     #[test]
     fn should_implement_serialize() {
         let dimensions = WindowDimensions::new(1280, 720);
-        let toml_str = toml::to_string(&window_settings).unwrap();
+        let toml_str = toml::to_string(&dimensions).unwrap();
 
         assert_eq!(
             toml_str,

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -1,5 +1,8 @@
 //! Provides a high-level, back-end agnostic window API for [Wolf
 //! Engine](https://docs.rs/wolf_engine/latest).
+//!
+//! See [wolf_engine::window](https://docs.rs/wolf_engine/latest/wolf_engine/window/index.html/) 
+//! for more details.
 
 mod window;
 pub use window::*;

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -4,6 +4,9 @@
 mod window_settings;
 pub use window_settings::*;
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 #[cfg(test)]
 use mockall::automock;
 
@@ -11,6 +14,8 @@ pub mod prelude {
     pub use super::*;
 }
 
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize)]
 pub struct WindowDimensions {
     pub width: usize,
     pub height: usize,

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -54,12 +54,16 @@ pub mod window_api_tests {
         window.expect_height()
             .once()
             .returning(|| 600);
+        window.expect_size()
+            .once()
+            .returning(|| (800, 600));
         window.expect_set_size()
             .once()
             .return_const(());
 
         let _width = window.width();
         let _height = window.height();
+        let _size = window.size();
         window.set_size((800, 600));
     }
 

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -6,7 +6,6 @@ pub use window_settings::*;
 
 #[cfg(test)]
 use mockall::automock;
-use winit::window::Fullscreen;
 
 pub mod prelude {
     pub use super::*;
@@ -81,7 +80,7 @@ pub mod window_api_tests {
             .returning(|| None);
         window.expect_set_fullscreen_mode()
             .once()
-            .returnconst(());
+            .return_const(());
         window.expect_is_fullscreen()
             .once()
             .returning(|| false);

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -27,6 +27,12 @@ impl WindowDimensions {
     }
 }
 
+impl From<(usize, usize)> for WindowDimensions {
+    fn from(dimensions: (usize, usize)) -> Self {
+        Self::new(dimensions.0.into(), dimensions.1.into())
+    }
+}
+
 #[cfg(test)]
 mod window_dimensions_tests {
     use super::*; 

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -29,7 +29,6 @@ pub trait Window {
     fn fullscreen_mode(&self) -> Option<FullscreenMode>;
     fn set_fullscreen_mode(&mut self, fullscreen_mode: Option<FullscreenMode>);
     fn is_fullscreen(&self) -> bool;
-
 }
 
 #[cfg(test)]
@@ -39,12 +38,11 @@ pub mod window_api_tests {
     #[test]
     fn should_have_title_setter_and_accessor() {
         let (mut window, _backend) = mock_window(WindowSettings::default());
-        window.expect_title()
+        window
+            .expect_title()
             .once()
             .returning(|| "Test".to_string());
-        window.expect_set_title()
-            .once()
-            .return_const(());
+        window.expect_set_title().once().return_const(());
 
         let _title = window.title();
         window.set_title("Hello, World!");
@@ -53,18 +51,10 @@ pub mod window_api_tests {
     #[test]
     fn should_have_size_settors_and_getters() {
         let (mut window, _backend) = mock_window(WindowSettings::default());
-        window.expect_width()
-            .once()
-            .returning(|| 800);
-        window.expect_height()
-            .once()
-            .returning(|| 600);
-        window.expect_size()
-            .once()
-            .returning(|| (800, 600));
-        window.expect_set_size()
-            .once()
-            .return_const(());
+        window.expect_width().once().returning(|| 800);
+        window.expect_height().once().returning(|| 600);
+        window.expect_size().once().returning(|| (800, 600));
+        window.expect_set_size().once().return_const(());
 
         let _width = window.width();
         let _height = window.height();
@@ -75,16 +65,10 @@ pub mod window_api_tests {
     #[test]
     fn should_have_fullscreen_mode_getters_and_setters() {
         let (mut window, _backend) = mock_window(WindowSettings::default());
-        window.expect_fullscreen_mode()
-            .once()
-            .returning(|| None);
-        window.expect_set_fullscreen_mode()
-            .once()
-            .return_const(());
-        window.expect_is_fullscreen()
-            .once()
-            .returning(|| false);
-        
+        window.expect_fullscreen_mode().once().returning(|| None);
+        window.expect_set_fullscreen_mode().once().return_const(());
+        window.expect_is_fullscreen().once().returning(|| false);
+
         let _fullscreen_mode = window.fullscreen_mode();
         let _is_fullscreen = window.is_fullscreen();
         window.set_fullscreen_mode(Some(FullscreenMode::Fullscreen));
@@ -92,10 +76,11 @@ pub mod window_api_tests {
 
     fn mock_window(settings: WindowSettings) -> (MockWindow, MockWindowBackend) {
         let mut backend = MockWindowBackend::new();
-        backend.expect_create_window()
+        backend
+            .expect_create_window()
             .once()
             .returning(|_| Ok(MockWindow::new()));
         let window = backend.create_window(settings).unwrap();
-        (window, backend) 
+        (window, backend)
     }
 }

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -6,6 +6,7 @@ pub use window_settings::*;
 
 #[cfg(test)]
 use mockall::automock;
+use winit::window::Fullscreen;
 
 pub mod prelude {
     pub use super::*;
@@ -26,6 +27,10 @@ pub trait Window {
     fn height(&self) -> usize;
     fn size(&self) -> (usize, usize);
     fn set_size(&mut self, size: (usize, usize));
+    fn fullscreen_mode(&self) -> Option<FullscreenMode>;
+    fn set_fullscreen_mode(&mut self, fullscreen_mode: Option<FullscreenMode>);
+    fn is_fullscreen(&self) -> bool;
+
 }
 
 #[cfg(test)]

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -11,8 +11,21 @@ pub mod prelude {
     pub use super::*;
 }
 
+pub struct WindowDimensions {
+    pub width: usize,
+    pub height: usize,
+}
+
+impl WindowDimensions {
+    pub fn new(width: usize, height: usize) -> Self {
+        Self { width: 0, height: 0 }
+    }
+}
+
 #[cfg(test)]
 mod window_dimensions_tests {
+    use super::*; 
+
     #[test]
     pub fn should_have_width_and_height() {
         let dimensions = WindowDimensions::new(800, 600);

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -18,7 +18,7 @@ pub struct WindowDimensions {
 
 impl WindowDimensions {
     pub fn new(width: usize, height: usize) -> Self {
-        Self { width: 0, height: 0 }
+        Self { width, height }
     }
 }
 

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -8,6 +8,8 @@ mod window;
 pub use window::*;
 mod window_dimensions;
 pub use window_dimensions::*;
+mod window_id;
+pub use window_id::*;
 mod window_settings;
 pub use window_settings::*;
 

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -3,76 +3,11 @@
 
 mod window;
 pub use window::*;
+mod window_dimensions;
+pub use window_dimensions::*;
 mod window_settings;
 pub use window_settings::*;
-
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 
 pub mod prelude {
     pub use super::*;
 }
-
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct WindowDimensions {
-    pub width: usize,
-    pub height: usize,
-}
-
-impl WindowDimensions {
-    pub fn new(width: usize, height: usize) -> Self {
-        Self { width, height }
-    }
-}
-
-impl From<(usize, usize)> for WindowDimensions {
-    fn from(dimensions: (usize, usize)) -> Self {
-        Self::new(dimensions.0.into(), dimensions.1.into())
-    }
-}
-
-#[cfg(test)]
-mod window_dimensions_tests {
-    use super::*;
-
-    #[test]
-    pub fn should_have_width_and_height() {
-        let dimensions = WindowDimensions::new(800, 600);
-        assert_eq!(dimensions.width, 800);
-        assert_eq!(dimensions.height, 600);
-    }
-
-    #[test]
-    fn should_convert_from_tuple() {
-        let dimensions: WindowDimensions = (800, 600).into();
-        assert_eq!(dimensions.width, 800);
-        assert_eq!(dimensions.height, 600);
-    }
-
-    #[cfg(feature = "serde")]
-    #[test]
-    fn should_implement_deserialize() {
-        let toml_str = r#"
-        width = 800
-        height = 600
-        "#;
-        let dimensions: WindowDimensions = toml::from_str(toml_str).unwrap();
-        assert_eq!(dimensions.width, 800);
-        assert_eq!(dimensions.height, 600);
-    }
-
-    #[cfg(feature = "serde")]
-    #[test]
-    fn should_implement_serialize() {
-        let dimensions = WindowDimensions::new(1280, 720);
-        let toml_str = toml::to_string(&dimensions).unwrap();
-
-        assert_eq!(
-            toml_str,
-            "width = 1280\n".to_owned() + &"height = 720\n".to_owned()
-        );
-    }
-}
-

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -24,6 +24,7 @@ pub trait Window {
     fn set_title(&mut self, title: &str);
     fn width(&self) -> usize;
     fn height(&self) -> usize;
+    fn size(&self) -> (usize, usize);
     fn set_size(&mut self, size: (usize, usize));
 }
 
@@ -65,6 +66,24 @@ pub mod window_api_tests {
         let _height = window.height();
         let _size = window.size();
         window.set_size((800, 600));
+    }
+
+    #[test]
+    fn should_have_fullscreen_mode_getters_and_setters() {
+        let (mut window, _backend) = mock_window(WindowSettings::default());
+        window.expect_fullscreen_mode()
+            .once()
+            .returning(|| None);
+        window.expect_set_fullscreen_mode()
+            .once()
+            .returnconst(());
+        window.expect_is_fullscreen()
+            .once()
+            .returning(|| false);
+        
+        let _fullscreen_mode = window.fullscreen_mode();
+        let _is_fullscreen = window.is_fullscreen();
+        window.set_fullscreen_mode(Some(FullscreenMode::Fullscreen));
     }
 
     fn mock_window(settings: WindowSettings) -> (MockWindow, MockWindowBackend) {

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -9,8 +9,6 @@ pub use window_settings::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[cfg(test)]
-use mockall::automock;
 
 pub mod prelude {
     pub use super::*;

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -8,6 +8,7 @@ pub use window_dimensions::*;
 mod window_settings;
 pub use window_settings::*;
 
+#[doc(hidden)]
 pub mod prelude {
     pub use super::*;
 }

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -15,7 +15,7 @@ pub mod prelude {
 }
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WindowDimensions {
     pub width: usize,
     pub height: usize,

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -11,6 +11,16 @@ pub mod prelude {
     pub use super::*;
 }
 
+#[cfg(test)]
+mod window_dimensions_tests {
+    #[test]
+    pub fn should_have_width_and_height() {
+        let dimensions = WindowDimensions::new(800, 600);
+        assert_eq!(dimensions.width, 800);
+        assert_eq!(dimensions.height, 600);
+    }
+}
+
 #[cfg_attr(test, automock(type Window = MockWindow;))]
 pub trait WindowBackend {
     type Window: Window;

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -32,6 +32,30 @@ mod window_dimensions_tests {
         assert_eq!(dimensions.width, 800);
         assert_eq!(dimensions.height, 600);
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn should_implement_deserialize() {
+        let toml_str = r#"
+        width = 800
+        height = 600
+        "#;
+        let dimensions: WindowDimensions = toml::from_str(toml_str).unwrap();
+        assert_eq!(window_settings.title, "Hello, world");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn should_implement_serialize() {
+        let dimensions = WindowDimensions::new(1280, 720);
+        let toml_str = toml::to_string(&window_settings).unwrap();
+
+        assert_eq!(
+            toml_str,
+            "width = 1280\n".to_owned()
+                + &"height = 720\n".to_owned()
+        );
+    }
 }
 
 #[cfg_attr(test, automock(type Window = MockWindow;))]

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -1,6 +1,8 @@
 //! Provides a high-level, back-end agnostic window API for [Wolf
 //! Engine](https://docs.rs/wolf_engine/latest).
 
+mod window;
+pub use window::*;
 mod window_settings;
 pub use window_settings::*;
 
@@ -76,82 +78,3 @@ mod window_dimensions_tests {
     }
 }
 
-#[cfg_attr(test, automock(type Window = MockWindow;))]
-pub trait WindowBackend {
-    type Window: Window;
-
-    fn create_window(&mut self, settings: WindowSettings) -> Result<Self::Window, String>;
-}
-
-#[cfg_attr(test, automock)]
-pub trait Window {
-    fn title(&self) -> String;
-    fn set_title<T: Into<String> + 'static>(&mut self, title: T);
-    fn width(&self) -> usize;
-    fn height(&self) -> usize;
-    fn size(&self) -> WindowDimensions;
-    fn set_size<T: Into<WindowDimensions> + 'static>(&mut self, size: T);
-    fn fullscreen_mode(&self) -> Option<FullscreenMode>;
-    fn set_fullscreen_mode(&mut self, fullscreen_mode: Option<FullscreenMode>);
-    fn is_fullscreen(&self) -> bool;
-}
-
-#[cfg(test)]
-pub mod window_api_tests {
-    use super::*;
-
-    #[test]
-    fn should_have_title_setter_and_accessor() {
-        let (mut window, _backend) = mock_window(WindowSettings::default());
-        window
-            .expect_title()
-            .once()
-            .returning(|| "Test".to_string());
-        window.expect_set_title::<&str>().once().return_const(());
-
-        let _title = window.title();
-        window.set_title("Hello, World!");
-    }
-
-    #[test]
-    fn should_have_size_settors_and_getters() {
-        let (mut window, _backend) = mock_window(WindowSettings::default());
-        window.expect_width().once().returning(|| 800);
-        window.expect_height().once().returning(|| 600);
-        window
-            .expect_size()
-            .once()
-            .returning(|| WindowDimensions::new(800, 600));
-        window
-            .expect_set_size::<(usize, usize)>()
-            .once()
-            .return_const(());
-
-        let _width = window.width();
-        let _height = window.height();
-        let _size = window.size();
-        window.set_size((800, 600));
-    }
-
-    #[test]
-    fn should_have_fullscreen_mode_getters_and_setters() {
-        let (mut window, _backend) = mock_window(WindowSettings::default());
-        window.expect_fullscreen_mode().once().returning(|| None);
-        window.expect_set_fullscreen_mode().once().return_const(());
-        window.expect_is_fullscreen().once().returning(|| false);
-
-        let _fullscreen_mode = window.fullscreen_mode();
-        let _is_fullscreen = window.is_fullscreen();
-        window.set_fullscreen_mode(Some(FullscreenMode::Fullscreen));
-    }
-
-    fn mock_window(settings: WindowSettings) -> (MockWindow, MockWindowBackend) {
-        let mut backend = MockWindowBackend::new();
-        backend
-            .expect_create_window()
-            .once()
-            .returning(|_| Ok(MockWindow::new()));
-        let window = backend.create_window(settings).unwrap();
-        (window, backend)
-    }
-}

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -87,11 +87,11 @@ pub trait WindowBackend {
 #[cfg_attr(test, automock)]
 pub trait Window {
     fn title(&self) -> String;
-    fn set_title(&mut self, title: &str);
+    fn set_title<T: Into<String> + 'static>(&mut self, title: T);
     fn width(&self) -> usize;
     fn height(&self) -> usize;
-    fn size(&self) -> (usize, usize);
-    fn set_size(&mut self, size: (usize, usize));
+    fn size(&self) -> WindowDimensions;
+    fn set_size<T: Into<WindowDimensions> + 'static>(&mut self, size: T);
     fn fullscreen_mode(&self) -> Option<FullscreenMode>;
     fn set_fullscreen_mode(&mut self, fullscreen_mode: Option<FullscreenMode>);
     fn is_fullscreen(&self) -> bool;
@@ -108,7 +108,7 @@ pub mod window_api_tests {
             .expect_title()
             .once()
             .returning(|| "Test".to_string());
-        window.expect_set_title().once().return_const(());
+        window.expect_set_title::<&str>().once().return_const(());
 
         let _title = window.title();
         window.set_title("Hello, World!");
@@ -119,8 +119,8 @@ pub mod window_api_tests {
         let (mut window, _backend) = mock_window(WindowSettings::default());
         window.expect_width().once().returning(|| 800);
         window.expect_height().once().returning(|| 600);
-        window.expect_size().once().returning(|| (800, 600));
-        window.expect_set_size().once().return_const(());
+        window.expect_size().once().returning(|| WindowDimensions::new(800, 600));
+        window.expect_set_size::<(usize, usize)>().once().return_const(());
 
         let _width = window.width();
         let _height = window.height();

--- a/wolf_engine_window/src/lib.rs
+++ b/wolf_engine_window/src/lib.rs
@@ -5,7 +5,7 @@ mod window_settings;
 pub use window_settings::*;
 
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 use mockall::automock;
@@ -35,7 +35,7 @@ impl From<(usize, usize)> for WindowDimensions {
 
 #[cfg(test)]
 mod window_dimensions_tests {
-    use super::*; 
+    use super::*;
 
     #[test]
     pub fn should_have_width_and_height() {
@@ -71,8 +71,7 @@ mod window_dimensions_tests {
 
         assert_eq!(
             toml_str,
-            "width = 1280\n".to_owned()
-                + &"height = 720\n".to_owned()
+            "width = 1280\n".to_owned() + &"height = 720\n".to_owned()
         );
     }
 }
@@ -119,8 +118,14 @@ pub mod window_api_tests {
         let (mut window, _backend) = mock_window(WindowSettings::default());
         window.expect_width().once().returning(|| 800);
         window.expect_height().once().returning(|| 600);
-        window.expect_size().once().returning(|| WindowDimensions::new(800, 600));
-        window.expect_set_size::<(usize, usize)>().once().return_const(());
+        window
+            .expect_size()
+            .once()
+            .returning(|| WindowDimensions::new(800, 600));
+        window
+            .expect_set_size::<(usize, usize)>()
+            .once()
+            .return_const(());
 
         let _width = window.width();
         let _height = window.height();

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -94,6 +94,14 @@ pub mod window_api_tests {
     use raw_window_handle::{WebWindowHandle, WebDisplayHandle};
 
     #[test]
+    fn should_have_id_getter() {
+        let (mut window, _backend) = mock_window(WindowSettings::default());
+        window.expect_id().once().returning(WindowId::new());
+
+        let _id = window.id();
+    }
+
+    #[test]
     fn should_have_title_setter_and_accessor() {
         let (mut window, _backend) = mock_window(WindowSettings::default());
         window

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -1,12 +1,12 @@
 use crate::{FullscreenMode, WindowDimensions, WindowSettings};
 
-use raw_window_handle::HasRawWindowHandle;
+use raw_window_handle::{HasRawWindowHandle, HasRawDisplayHandle};
 
 #[cfg(test)]
 use mockall::{mock, automock};
 
 #[cfg(test)]
-use raw_window_handle::RawWindowHandle;
+use raw_window_handle::{RawWindowHandle, RawDisplayHandle};
 
 /// Provides a high-level API for creating, and working with [`Windows`](Window).
 #[cfg_attr(test, automock(type Window = MockWindow;))]
@@ -141,6 +141,15 @@ pub mod window_api_tests {
             .once()
             .returning(|| RawWindowHandle::Web(WebWindowHandle::empty()));
         let _handle = window.raw_window_handle();
+    }
+
+    #[test]
+    fn should_implement_raw_display_handle() {
+        let (mut window, _backend) = mock_window(WindowSettings::default());
+        window.expect_raw_display_handle()
+            .once()
+            .returning(|| RawDisplayHandle::Web(WebDisplayHandle::empty()));
+        let _handle = window.raw_display_handle();
     }
 
     fn mock_window(settings: WindowSettings) -> (MockWindow, MockWindowBackend) {

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -1,0 +1,88 @@
+use crate::{WindowSettings, FullscreenMode, WindowDimensions};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+use mockall::automock;
+
+
+#[cfg_attr(test, automock(type Window = MockWindow;))]
+pub trait WindowBackend {
+    type Window: Window;
+
+    fn create_window(&mut self, settings: WindowSettings) -> Result<Self::Window, String>;
+}
+
+#[cfg_attr(test, automock)]
+pub trait Window {
+    fn title(&self) -> String;
+    fn set_title<T: Into<String> + 'static>(&mut self, title: T);
+    fn width(&self) -> usize;
+    fn height(&self) -> usize;
+    fn size(&self) -> WindowDimensions;
+    fn set_size<T: Into<WindowDimensions> + 'static>(&mut self, size: T);
+    fn fullscreen_mode(&self) -> Option<FullscreenMode>;
+    fn set_fullscreen_mode(&mut self, fullscreen_mode: Option<FullscreenMode>);
+    fn is_fullscreen(&self) -> bool;
+}
+
+#[cfg(test)]
+pub mod window_api_tests {
+    use super::*;
+
+    #[test]
+    fn should_have_title_setter_and_accessor() {
+        let (mut window, _backend) = mock_window(WindowSettings::default());
+        window
+            .expect_title()
+            .once()
+            .returning(|| "Test".to_string());
+        window.expect_set_title::<&str>().once().return_const(());
+
+        let _title = window.title();
+        window.set_title("Hello, World!");
+    }
+
+    #[test]
+    fn should_have_size_settors_and_getters() {
+        let (mut window, _backend) = mock_window(WindowSettings::default());
+        window.expect_width().once().returning(|| 800);
+        window.expect_height().once().returning(|| 600);
+        window
+            .expect_size()
+            .once()
+            .returning(|| WindowDimensions::new(800, 600));
+        window
+            .expect_set_size::<(usize, usize)>()
+            .once()
+            .return_const(());
+
+        let _width = window.width();
+        let _height = window.height();
+        let _size = window.size();
+        window.set_size((800, 600));
+    }
+
+    #[test]
+    fn should_have_fullscreen_mode_getters_and_setters() {
+        let (mut window, _backend) = mock_window(WindowSettings::default());
+        window.expect_fullscreen_mode().once().returning(|| None);
+        window.expect_set_fullscreen_mode().once().return_const(());
+        window.expect_is_fullscreen().once().returning(|| false);
+
+        let _fullscreen_mode = window.fullscreen_mode();
+        let _is_fullscreen = window.is_fullscreen();
+        window.set_fullscreen_mode(Some(FullscreenMode::Fullscreen));
+    }
+
+    fn mock_window(settings: WindowSettings) -> (MockWindow, MockWindowBackend) {
+        let mut backend = MockWindowBackend::new();
+        backend
+            .expect_create_window()
+            .once()
+            .returning(|_| Ok(MockWindow::new()));
+        let window = backend.create_window(settings).unwrap();
+        (window, backend)
+    }
+}

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -26,7 +26,7 @@ pub trait WindowBackend {
 /// # Examples
 ///
 /// A new window is created by passing [`WindowSettings`] to a [`WindowBackend`].
-pub trait Window: HasRawWindowHandle {
+pub trait Window: HasRawWindowHandle + HasRawDisplayHandle {
 
     /// Return the window's title.
     fn title(&self) -> String;

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -3,11 +3,11 @@ use crate::{FullscreenMode, WindowDimensions, WindowSettings};
 #[cfg(test)]
 use mockall::automock;
 
-/// Provides a high-level API for creating, and working with [Windows](Window).
+/// Provides a high-level API for creating, and working with [`Windows`](Window).
 #[cfg_attr(test, automock(type Window = MockWindow;))]
 pub trait WindowBackend {
     
-    /// The [Window] type used by this window implementation.
+    /// The [`Window`] type used by this window implementation.
     type Window: Window;
     
     /// Create a window with the provided settings.

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -1,4 +1,4 @@
-use crate::{FullscreenMode, WindowDimensions, WindowSettings};
+use crate::*;
 
 use raw_window_handle::{HasRawWindowHandle, HasRawDisplayHandle};
 

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -1,4 +1,4 @@
-use crate::{WindowSettings, FullscreenMode, WindowDimensions};
+use crate::{FullscreenMode, WindowDimensions, WindowSettings};
 
 #[cfg(test)]
 use mockall::automock;

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -1,39 +1,37 @@
 use crate::*;
 
-use raw_window_handle::{HasRawWindowHandle, HasRawDisplayHandle};
+use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 
 #[cfg(test)]
-use mockall::{mock, automock};
+use mockall::{automock, mock};
 
 #[cfg(test)]
-use raw_window_handle::{RawWindowHandle, RawDisplayHandle};
+use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 
 /// Provides a high-level API for creating, and working with [`Windows`](Window).
 #[cfg_attr(test, automock(type Window = MockWindow;))]
 pub trait WindowBackend {
-    
     /// The [`Window`] type used by this window implementation.
     type Window: Window;
-    
+
     /// Create a window with the provided settings.
     ///
     /// Returns a [`Result`] containing a [`Window`], or a message explaining what went wrong.
     fn create_window(&mut self, settings: WindowSettings) -> Result<Self::Window, String>;
 }
 
-/// Provides a high-level, back-end agnostic window API. 
+/// Provides a high-level, back-end agnostic window API.
 ///
 /// # Examples
 ///
 /// A new window is created by passing [`WindowSettings`] to a [`WindowBackend`].
 pub trait Window: HasRawWindowHandle + HasRawDisplayHandle {
-
     /// Return the window's unique id.
     fn id(&self) -> WindowId;
 
     /// Return the window's title.
     fn title(&self) -> String;
-    
+
     /// Set the window's title.
     fn set_title<T: Into<String> + 'static>(&mut self, title: T);
 
@@ -66,7 +64,7 @@ pub trait Window: HasRawWindowHandle + HasRawDisplayHandle {
 
 #[cfg(test)]
 mock! {
-    pub Window {} 
+    pub Window {}
 
     impl Window for Window {
         fn id(&self) -> WindowId;
@@ -90,12 +88,11 @@ mock! {
     }
 }
 
-
 #[cfg(test)]
 pub mod window_api_tests {
     use super::*;
-    
-    use raw_window_handle::{WebWindowHandle, WebDisplayHandle};
+
+    use raw_window_handle::{WebDisplayHandle, WebWindowHandle};
 
     #[test]
     fn should_have_id_getter() {
@@ -153,7 +150,8 @@ pub mod window_api_tests {
     #[test]
     fn should_implement_raw_window_handle() {
         let (mut window, _backend) = mock_window(WindowSettings::default());
-        window.expect_raw_window_handle()
+        window
+            .expect_raw_window_handle()
             .once()
             .returning(|| RawWindowHandle::Web(WebWindowHandle::empty()));
         let _handle = window.raw_window_handle();
@@ -162,7 +160,8 @@ pub mod window_api_tests {
     #[test]
     fn should_implement_raw_display_handle() {
         let (mut window, _backend) = mock_window(WindowSettings::default());
-        window.expect_raw_display_handle()
+        window
+            .expect_raw_display_handle()
             .once()
             .returning(|| RawDisplayHandle::Web(WebDisplayHandle::empty()));
         let _handle = window.raw_display_handle();

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -100,7 +100,7 @@ pub mod window_api_tests {
     #[test]
     fn should_have_id_getter() {
         let (mut window, _backend) = mock_window(WindowSettings::default());
-        window.expect_id().once().returning(WindowId::new());
+        window.expect_id().once().returning(|| WindowId::new());
 
         let _id = window.id();
     }

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -3,7 +3,10 @@ use crate::{FullscreenMode, WindowDimensions, WindowSettings};
 use raw_window_handle::HasRawWindowHandle;
 
 #[cfg(test)]
-use mockall::automock;
+use mockall::{mock, automock};
+
+#[cfg(test)]
+use raw_window_handle::RawWindowHandle;
 
 /// Provides a high-level API for creating, and working with [`Windows`](Window).
 #[cfg_attr(test, automock(type Window = MockWindow;))]
@@ -23,7 +26,6 @@ pub trait WindowBackend {
 /// # Examples
 ///
 /// A new window is created by passing [`WindowSettings`] to a [`WindowBackend`].
-#[cfg_attr(test, automock)]
 pub trait Window: HasRawWindowHandle {
     fn title(&self) -> String;
     fn set_title<T: Into<String> + 'static>(&mut self, title: T);
@@ -35,6 +37,28 @@ pub trait Window: HasRawWindowHandle {
     fn set_fullscreen_mode(&mut self, fullscreen_mode: Option<FullscreenMode>);
     fn is_fullscreen(&self) -> bool;
 }
+
+#[cfg(test)]
+mock! {
+    pub Window {} 
+
+    impl Window for Window {
+        fn title(&self) -> String;
+        fn set_title<T: Into<String> + 'static>(&mut self, title: T);
+        fn width(&self) -> usize;
+        fn height(&self) -> usize;
+        fn size(&self) -> WindowDimensions;
+        fn set_size<T: Into<WindowDimensions> + 'static>(&mut self, size: T);
+        fn fullscreen_mode(&self) -> Option<FullscreenMode>;
+        fn set_fullscreen_mode(&mut self, fullscreen_mode: Option<FullscreenMode>);
+        fn is_fullscreen(&self) -> bool;
+    }
+
+    unsafe impl HasRawWindowHandle for Window {
+        fn raw_window_handle(&self) -> RawWindowHandle;
+    }
+}
+
 
 #[cfg(test)]
 pub mod window_api_tests {

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -91,7 +91,7 @@ mock! {
 pub mod window_api_tests {
     use super::*;
     
-    use raw_window_handle::{RawWindowHandle, WebWindowHandle};
+    use raw_window_handle::{WebWindowHandle, WebDisplayHandle};
 
     #[test]
     fn should_have_title_setter_and_accessor() {

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -117,9 +117,7 @@ pub mod window_api_tests {
         window.expect_raw_window_handle()
             .once()
             .returning(|| RawWindowHandle::Web(WebWindowHandle::empty()));
-        unsafe {
-            let handle = window.raw_window_handle();
-        }
+        let _handle = window.raw_window_handle();
     }
 
     fn mock_window(settings: WindowSettings) -> (MockWindow, MockWindowBackend) {

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -16,6 +16,20 @@ pub trait WindowBackend {
     fn create_window(&mut self, settings: WindowSettings) -> Result<Self::Window, String>;
 }
 
+/// Provides a high-level, back-end agnostic window API. 
+///
+/// # Examples
+///
+/// A new window is created by passing [`WindowSettings`] to a [`WindowBackend`].
+///
+/// ```
+/// # use wolf_engine_window::prelude::*;
+/// #
+/// # let window_backend = TestWindowBackend::new();
+/// #
+/// let window_settings = WindowSettings::default();
+/// let window = window_backend.create_window(window_settings).unwrap();
+/// ```
 #[cfg_attr(test, automock)]
 pub trait Window {
     fn title(&self) -> String;

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -1,5 +1,7 @@
 use crate::{FullscreenMode, WindowDimensions, WindowSettings};
 
+use raw_window_handle::HasRawWindowHandle;
+
 #[cfg(test)]
 use mockall::automock;
 
@@ -22,7 +24,7 @@ pub trait WindowBackend {
 ///
 /// A new window is created by passing [`WindowSettings`] to a [`WindowBackend`].
 #[cfg_attr(test, automock)]
-pub trait Window {
+pub trait Window: HasRawWindowHandle {
     fn title(&self) -> String;
     fn set_title<T: Into<String> + 'static>(&mut self, title: T);
     fn width(&self) -> usize;
@@ -37,6 +39,8 @@ pub trait Window {
 #[cfg(test)]
 pub mod window_api_tests {
     use super::*;
+    
+    use raw_window_handle::{RawWindowHandle, WebWindowHandle};
 
     #[test]
     fn should_have_title_setter_and_accessor() {
@@ -89,6 +93,9 @@ pub mod window_api_tests {
         window.expect_raw_window_handle()
             .once()
             .returning(|| RawWindowHandle::Web(WebWindowHandle::empty()));
+        unsafe {
+            let handle = window.raw_window_handle();
+        }
     }
 
     fn mock_window(settings: WindowSettings) -> (MockWindow, MockWindowBackend) {

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -1,11 +1,7 @@
 use crate::{WindowSettings, FullscreenMode, WindowDimensions};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(test)]
 use mockall::automock;
-
 
 #[cfg_attr(test, automock(type Window = MockWindow;))]
 pub trait WindowBackend {

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -21,15 +21,6 @@ pub trait WindowBackend {
 /// # Examples
 ///
 /// A new window is created by passing [`WindowSettings`] to a [`WindowBackend`].
-///
-/// ```
-/// # use wolf_engine_window::prelude::*;
-/// #
-/// # let window_backend = TestWindowBackend::new();
-/// #
-/// let window_settings = WindowSettings::default();
-/// let window = window_backend.create_window(window_settings).unwrap();
-/// ```
 #[cfg_attr(test, automock)]
 pub trait Window {
     fn title(&self) -> String;

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -3,10 +3,16 @@ use crate::{FullscreenMode, WindowDimensions, WindowSettings};
 #[cfg(test)]
 use mockall::automock;
 
+/// Provides a high-level API for creating, and working with [Windows](Window).
 #[cfg_attr(test, automock(type Window = MockWindow;))]
 pub trait WindowBackend {
+    
+    /// The [Window] type used by this window implementation.
     type Window: Window;
-
+    
+    /// Create a window with the provided settings.
+    ///
+    /// Returns a [`Result`] containing a [`Window`], or a message explaining what went wrong.
     fn create_window(&mut self, settings: WindowSettings) -> Result<Self::Window, String>;
 }
 

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -27,14 +27,37 @@ pub trait WindowBackend {
 ///
 /// A new window is created by passing [`WindowSettings`] to a [`WindowBackend`].
 pub trait Window: HasRawWindowHandle {
+
+    /// Return the window's title.
     fn title(&self) -> String;
+    
+    /// Set the window's title.
     fn set_title<T: Into<String> + 'static>(&mut self, title: T);
+
+    /// Return the window's width, in pixels.
     fn width(&self) -> usize;
+
+    /// Return the window's height, in pixels.
     fn height(&self) -> usize;
+
+    /// Return the window's size.
     fn size(&self) -> WindowDimensions;
+
+    /// Set the window's size.
     fn set_size<T: Into<WindowDimensions> + 'static>(&mut self, size: T);
+
+    /// Return the window's [`FullscreenMode`] if there is one.
     fn fullscreen_mode(&self) -> Option<FullscreenMode>;
+
+    /// Set the window's [`FullscreenMode`].
+    ///
+    /// Setting this value to `None` for "windowed" mode.
     fn set_fullscreen_mode(&mut self, fullscreen_mode: Option<FullscreenMode>);
+
+    /// Return `true` if the window is in fullscreen mode.
+    ///
+    /// If the [`FullscreenMode`] is [`Some`], `true` is returned.
+    /// If [`None`], then `false` is returned.
     fn is_fullscreen(&self) -> bool;
 }
 

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -80,6 +80,10 @@ mock! {
     unsafe impl HasRawWindowHandle for Window {
         fn raw_window_handle(&self) -> RawWindowHandle;
     }
+
+    unsafe impl HasRawDisplayHandle for Window {
+        fn raw_display_handle(&self) -> RawDisplayHandle;
+    }
 }
 
 

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -83,6 +83,14 @@ pub mod window_api_tests {
         window.set_fullscreen_mode(Some(FullscreenMode::Fullscreen));
     }
 
+    #[test]
+    fn should_implement_raw_window_handle() {
+        let (mut window, _backend) = mock_window(WindowSettings::default());
+        window.expect_raw_window_handle()
+            .once()
+            .returning(|| RawWindowHandle::Web(WebWindowHandle::empty()));
+    }
+
     fn mock_window(settings: WindowSettings) -> (MockWindow, MockWindowBackend) {
         let mut backend = MockWindowBackend::new();
         backend

--- a/wolf_engine_window/src/window.rs
+++ b/wolf_engine_window/src/window.rs
@@ -28,6 +28,9 @@ pub trait WindowBackend {
 /// A new window is created by passing [`WindowSettings`] to a [`WindowBackend`].
 pub trait Window: HasRawWindowHandle + HasRawDisplayHandle {
 
+    /// Return the window's unique id.
+    fn id(&self) -> WindowId;
+
     /// Return the window's title.
     fn title(&self) -> String;
     
@@ -66,6 +69,7 @@ mock! {
     pub Window {} 
 
     impl Window for Window {
+        fn id(&self) -> WindowId;
         fn title(&self) -> String;
         fn set_title<T: Into<String> + 'static>(&mut self, title: T);
         fn width(&self) -> usize;

--- a/wolf_engine_window/src/window_dimensions.rs
+++ b/wolf_engine_window/src/window_dimensions.rs
@@ -20,7 +20,7 @@ impl WindowDimensions {
 
 impl From<(usize, usize)> for WindowDimensions {
     fn from(dimensions: (usize, usize)) -> Self {
-        Self::new(dimensions.0.into(), dimensions.1.into())
+        Self::new(dimensions.0, dimensions.1)
     }
 }
 

--- a/wolf_engine_window/src/window_dimensions.rs
+++ b/wolf_engine_window/src/window_dimensions.rs
@@ -5,14 +5,21 @@ pub mod prelude {
     pub use super::*;
 }
 
+/// Represents the size of a window, in pixels.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WindowDimensions {
+
+    /// The width of a window, in pixels.
     pub width: usize,
+
+    /// The height of a window, in pixels.
     pub height: usize,
 }
 
 impl WindowDimensions {
+
+    /// Create a new set of dimensions from the provide pixel values.
     pub fn new(width: usize, height: usize) -> Self {
         Self { width, height }
     }

--- a/wolf_engine_window/src/window_dimensions.rs
+++ b/wolf_engine_window/src/window_dimensions.rs
@@ -1,0 +1,68 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+pub mod prelude {
+    pub use super::*;
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct WindowDimensions {
+    pub width: usize,
+    pub height: usize,
+}
+
+impl WindowDimensions {
+    pub fn new(width: usize, height: usize) -> Self {
+        Self { width, height }
+    }
+}
+
+impl From<(usize, usize)> for WindowDimensions {
+    fn from(dimensions: (usize, usize)) -> Self {
+        Self::new(dimensions.0.into(), dimensions.1.into())
+    }
+}
+
+#[cfg(test)]
+mod window_dimensions_tests {
+    use super::*;
+
+    #[test]
+    pub fn should_have_width_and_height() {
+        let dimensions = WindowDimensions::new(800, 600);
+        assert_eq!(dimensions.width, 800);
+        assert_eq!(dimensions.height, 600);
+    }
+
+    #[test]
+    fn should_convert_from_tuple() {
+        let dimensions: WindowDimensions = (800, 600).into();
+        assert_eq!(dimensions.width, 800);
+        assert_eq!(dimensions.height, 600);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn should_implement_deserialize() {
+        let toml_str = r#"
+        width = 800
+        height = 600
+        "#;
+        let dimensions: WindowDimensions = toml::from_str(toml_str).unwrap();
+        assert_eq!(dimensions.width, 800);
+        assert_eq!(dimensions.height, 600);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn should_implement_serialize() {
+        let dimensions = WindowDimensions::new(1280, 720);
+        let toml_str = toml::to_string(&dimensions).unwrap();
+
+        assert_eq!(
+            toml_str,
+            "width = 1280\n".to_owned() + &"height = 720\n".to_owned()
+        );
+    }
+}

--- a/wolf_engine_window/src/window_dimensions.rs
+++ b/wolf_engine_window/src/window_dimensions.rs
@@ -9,7 +9,6 @@ pub mod prelude {
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WindowDimensions {
-
     /// The width of a window, in pixels.
     pub width: usize,
 
@@ -18,7 +17,6 @@ pub struct WindowDimensions {
 }
 
 impl WindowDimensions {
-
     /// Create a new set of dimensions from the provide pixel values.
     pub fn new(width: usize, height: usize) -> Self {
         Self { width, height }

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -13,12 +13,15 @@ fn read_and_incrament_next_id() -> usize {
 }
 
 /// Provides a unique id for keeping track of a [`Window`](crate::Window).
+///
+/// All new window IDs are guaranteed to be unique.  A window ID is only equal to copies of itself.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct WindowId {
     id: usize,
 }
 
 impl WindowId {
+    /// Create a new, unique window id.
     pub fn new() -> Self {
         Self {
             id: read_and_incrament_next_id(),

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -1,3 +1,4 @@
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct WindowId {}
 
 impl WindowId {

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -36,4 +36,13 @@ mod window_id_tests {
 
         assert_ne!(a, b);
     }
+
+    #[test]
+    fn should_be_equal_to_self() {
+        let original = WindowId::new();
+        let clone = original.clone();
+
+        assert_eq!(original, clone);
+    }
+    
 }

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -6,12 +6,22 @@ lazy_static! {
     static ref NEXT_ID: Arc<Mutex<usize>> = Arc::from(Mutex::from(0));
 }
 
+fn read_and_incrament_next_id() -> usize {
+    let id = *NEXT_ID.lock().unwrap();
+    *NEXT_ID.lock().unwrap() = id + 1;
+    id
+}
+
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub struct WindowId {}
+pub struct WindowId {
+    id: usize,
+}
 
 impl WindowId {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            id: read_and_incrament_next_id(),
+        }
     }
 }
 

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -12,6 +12,10 @@ fn read_and_incrament_next_id() -> usize {
     id
 }
 
+/// Provides a unique id for keeping track of a [`Window`].
+///
+/// Each window id is unique, but they can be copied.  Copies of a specific id are always equal to
+/// each other.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct WindowId {
     id: usize,

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -32,7 +32,7 @@ impl WindowId {
 impl Default for WindowId {
     fn default() -> Self {
         Self::new()
-    } 
+    }
 }
 
 #[cfg(test)]

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -5,3 +5,16 @@ impl WindowId {
         Self {}
     }
 }
+
+#[cfg(test)]
+mod window_id_tests {
+    use super::*;
+
+    #[test]
+    fn should_be_unique() {
+        let a = WindowId::new();
+        let b = WindowId::new();
+
+        assert_ne!(a, b);
+    }
+}

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -29,6 +29,12 @@ impl WindowId {
     }
 }
 
+impl Default for WindowId {
+    fn default() -> Self {
+        Self::new()
+    } 
+}
+
 #[cfg(test)]
 mod window_id_tests {
     use super::*;

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -1,0 +1,7 @@
+pub struct WindowId {}
+
+impl WindowId {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -45,5 +45,4 @@ mod window_id_tests {
 
         assert_eq!(original, clone);
     }
-    
 }

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -1,3 +1,11 @@
+use std::sync::{Arc, Mutex};
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref NEXT_ID: Arc<Mutex<usize>> = Arc::from(Mutex::from(0));
+}
+
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct WindowId {}
 

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -12,7 +12,7 @@ fn read_and_incrament_next_id() -> usize {
     id
 }
 
-/// Provides a unique id for keeping track of a [`Window`].
+/// Provides a unique id for keeping track of a [`Window`](crate::Window).
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct WindowId {
     id: usize,

--- a/wolf_engine_window/src/window_id.rs
+++ b/wolf_engine_window/src/window_id.rs
@@ -13,9 +13,6 @@ fn read_and_incrament_next_id() -> usize {
 }
 
 /// Provides a unique id for keeping track of a [`Window`].
-///
-/// Each window id is unique, but they can be copied.  Copies of a specific id are always equal to
-/// each other.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct WindowId {
     id: usize,

--- a/wolf_engine_window/src/window_settings.rs
+++ b/wolf_engine_window/src/window_settings.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// Represents the fullscreen mode.
 #[derive(Debug, PartialEq, Eq)]
@@ -15,7 +15,6 @@ pub enum FullscreenMode {
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WindowSettings {
-
     /// The desired title for the window.
     pub title: String,
 
@@ -35,7 +34,6 @@ pub struct WindowSettings {
 }
 
 impl WindowSettings {
-
     /// Create a new instance of `WindowSettings` with the default settings.
     ///
     /// Functionally identical to calling [`WindowSettings::default()`].
@@ -46,43 +44,42 @@ impl WindowSettings {
 
 /// Provides builder-style methods for configuring the window.
 impl WindowSettings {
-
     /// Set the title of the window.
     pub fn with_title(mut self, title: &str) -> Self {
         self.title = title.to_string();
         self
     }
-    
+
     /// Set the size, in pixels, of the window.
     pub fn with_size(mut self, size: (usize, usize)) -> Self {
         self.width = size.0;
         self.height = size.1;
         self
     }
-    
+
     /// Set the [`FullscreenMode`], if any, for the window.
     ///
     /// Use [`None`] to set to "windowed" mode.
     pub fn with_fullscreen(self) -> Self {
         self.with_fullscreen_mode(Some(FullscreenMode::Fullscreen))
     }
-    
+
     /// Set the window to borderless fullscreen mode.
     pub fn with_borderless_fullscreen(self) -> Self {
         self.with_fullscreen_mode(Some(FullscreenMode::Borderless))
     }
-    
+
     /// Set the window to exclusive fullscreen mode.
     pub fn with_fullscreen_mode(mut self, fullscreen_mode: Option<FullscreenMode>) -> Self {
         self.fullscreen_mode = fullscreen_mode;
         self
     }
-    
+
     /// Set the window to windowed mode.
     pub fn with_windowed(self) -> Self {
         self.with_fullscreen_mode(None)
     }
-    
+
     /// Set the resizable flag.
     pub fn with_resizable(mut self, is_resizable: bool) -> Self {
         self.is_resizable = is_resizable;
@@ -123,55 +120,47 @@ mod window_settings_tests {
 
     #[test]
     fn should_set_title() {
-        let settings = WindowSettings::new()
-            .with_title("Test Title");
+        let settings = WindowSettings::new().with_title("Test Title");
         assert_eq!(settings.title, "Test Title");
     }
 
     #[test]
     fn should_set_size() {
-        let settings = WindowSettings::new()
-            .with_size((800, 600));
+        let settings = WindowSettings::new().with_size((800, 600));
         assert_eq!(settings.width, 800);
         assert_eq!(settings.height, 600);
     }
 
     #[test]
     fn should_set_fullscreen_mode() {
-        let settings = WindowSettings::new()
-            .with_fullscreen_mode(Some(FullscreenMode::Fullscreen));
+        let settings = WindowSettings::new().with_fullscreen_mode(Some(FullscreenMode::Fullscreen));
         assert_eq!(settings.fullscreen_mode, Some(FullscreenMode::Fullscreen));
     }
 
     #[test]
     fn should_set_fullscreen() {
-        let settings = WindowSettings::new()
-            .with_fullscreen();
+        let settings = WindowSettings::new().with_fullscreen();
         assert_eq!(settings.fullscreen_mode, Some(FullscreenMode::Fullscreen));
     }
 
     #[test]
     fn should_set_to_borderless_fullscreen() {
-        let settings = WindowSettings::new()
-            .with_borderless_fullscreen();
+        let settings = WindowSettings::new().with_borderless_fullscreen();
         assert_eq!(settings.fullscreen_mode, Some(FullscreenMode::Borderless));
     }
 
     #[test]
     fn should_set_to_window_mode() {
-        let settings = WindowSettings::new()
-            .with_fullscreen();
+        let settings = WindowSettings::new().with_fullscreen();
         assert_eq!(settings.fullscreen_mode, Some(FullscreenMode::Fullscreen));
 
-        let settings = settings
-            .with_windowed();
+        let settings = settings.with_windowed();
         assert_eq!(settings.fullscreen_mode, None);
     }
 
     #[test]
     fn should_set_to_resizable() {
-        let settings = WindowSettings::new()
-            .with_resizable(false);
+        let settings = WindowSettings::new().with_resizable(false);
         assert_eq!(settings.is_resizable, false);
     }
 }
@@ -189,7 +178,7 @@ mod window_settings_serde_implementation_tests {
             height = 1080
             is_resizable = true
         "#;
-        let window_settings: WindowSettings = toml::from_str(toml_str).unwrap(); 
+        let window_settings: WindowSettings = toml::from_str(toml_str).unwrap();
         assert_eq!(window_settings.title, "Hello, world");
     }
 
@@ -201,9 +190,9 @@ mod window_settings_serde_implementation_tests {
         assert_eq!(
             toml_str,
             "title = \"Wolf Engine - Untitled Window\"\n".to_owned()
-            + &"width = 1280\n".to_owned()
-            + &"height = 720\n".to_owned()
-            + &"is_resizable = true\n".to_owned(),
+                + &"width = 1280\n".to_owned()
+                + &"height = 720\n".to_owned()
+                + &"is_resizable = true\n".to_owned(),
         );
     }
 }

--- a/wolf_engine_window/src/window_settings.rs
+++ b/wolf_engine_window/src/window_settings.rs
@@ -166,7 +166,7 @@ mod window_settings_tests {
         let settings = WindowSettings::new().with_resizable(false);
         assert_eq!(settings.is_resizable, false);
     }
-    
+
     #[cfg(feature = "serde")]
     #[test]
     fn should_implement_deserialize() {

--- a/wolf_engine_window/src/window_settings.rs
+++ b/wolf_engine_window/src/window_settings.rs
@@ -47,8 +47,8 @@ impl WindowSettings {
 /// Provides builder-style methods for configuring the window.
 impl WindowSettings {
     /// Set the title of the window.
-    pub fn with_title(mut self, title: &str) -> Self {
-        self.title = title.to_string();
+    pub fn with_title<T: Into<String>>(mut self, title: T) -> Self {
+        self.title = title.into();
         self
     }
 

--- a/wolf_engine_window/src/window_settings.rs
+++ b/wolf_engine_window/src/window_settings.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::WindowDimensions;
+
 /// Represents the fullscreen mode.
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -51,9 +53,10 @@ impl WindowSettings {
     }
 
     /// Set the size, in pixels, of the window.
-    pub fn with_size(mut self, size: (usize, usize)) -> Self {
-        self.width = size.0;
-        self.height = size.1;
+    pub fn with_size<T: Into<WindowDimensions>>(mut self, size: T) -> Self {
+        let dimensions: WindowDimensions = size.into();
+        self.width = dimensions.width;
+        self.height = dimensions.height;
         self
     }
 

--- a/wolf_engine_window/src/window_settings.rs
+++ b/wolf_engine_window/src/window_settings.rs
@@ -166,13 +166,8 @@ mod window_settings_tests {
         let settings = WindowSettings::new().with_resizable(false);
         assert_eq!(settings.is_resizable, false);
     }
-}
-
-#[cfg(test)]
-#[cfg(feature = "serde")]
-mod window_settings_serde_implementation_tests {
-    use super::*;
-
+    
+    #[cfg(feature = "serde")]
     #[test]
     fn should_implement_deserialize() {
         let toml_str = r#"
@@ -185,6 +180,7 @@ mod window_settings_serde_implementation_tests {
         assert_eq!(window_settings.title, "Hello, world");
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn should_implement_serialize() {
         let window_settings = WindowSettings::default();


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

Adds a high-level window API specific for Wolf Engine.  The main goals for this feature is to provide a common window API, with a consistent user experience regardless of what window system is being used under the hood.  This PR does't provide any integration with existing window systems, and it leaves out some of the specific implementation details, as these will be implemented in future PRs.  Specific details, such as window events, will be driven the development of the window back-ends.

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

<!-- Select one (Delete the rest): -->

- Minor

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [x] Added `wolf_engine_window` crate.
- [x] Added `window` feature.
- [x] Added `serde` feature.
- [x] Added `Window` trait.
- [x] Added `WindowBackend` trait.
- [x] Added `WindowId` struct.
- [x] Added `WindowSettings` struct.
- [x] Added `WindowDimensions` struct.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All compiler warnings have been resolved.
  - [x] All Clippy warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relevant examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch (`fetch origin/main && merge origin/main`.)
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
