### PR TITLE
Replace `logging::initialize_logging` argument with a custom `LogLevel` enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ serde = ["wolf_engine_window/serde"]
 
 [workspace]
 members = ["wolf_engine_*"]
+
+[[example]]
+name = "logging"
+required-features = ["logging"]

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -2,6 +2,6 @@ use wolf_engine::logging::*;
 
 pub fn main() {
     initialize_logging(LogLevel::Info);
-    
+
     log::info!("Hello, world!");
 }

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,0 +1,7 @@
+use wolf_engine::logging::*;
+
+pub fn main() {
+    initialize_logging(LogLevel::Info);
+    
+    log::info!("Hello, world!");
+}

--- a/tests/multi_thread_logging.rs
+++ b/tests/multi_thread_logging.rs
@@ -4,10 +4,11 @@ pub mod multi_threaded_logging_tests {
     use log::*;
     use std::thread;
     use wolf_engine::*;
+    use wolf_engine::logging::*;
 
     #[test]
     pub fn should_not_panic_in_multi_threaded_environment() {
-        logging::initialize_logging(LevelFilter::Info);
+        logging::initialize_logging(LogLevel::Info);
 
         let thread = thread::spawn(|| {
             info!("Hello, world!");

--- a/tests/multi_thread_logging.rs
+++ b/tests/multi_thread_logging.rs
@@ -3,8 +3,8 @@
 pub mod multi_threaded_logging_tests {
     use log::*;
     use std::thread;
-    use wolf_engine::*;
     use wolf_engine::logging::*;
+    use wolf_engine::*;
 
     #[test]
     pub fn should_not_panic_in_multi_threaded_environment() {

--- a/wolf_engine_core/src/logging.rs
+++ b/wolf_engine_core/src/logging.rs
@@ -1,7 +1,10 @@
 //! Provides a default logging implementation using [`SimpleLogger`].
 
-use log::LevelFilter;
 use simple_logger::SimpleLogger;
+
+pub enum LogLevel {
+    Debug,
+}
 
 /// Initializes the logging system with a pre-configured [SimpleLogger] instance.
 ///
@@ -25,7 +28,7 @@ use simple_logger::SimpleLogger;
 /// #
 /// info!("Hello, world!");
 /// ```
-pub fn initialize_logging(log_level: LevelFilter) {
+pub fn initialize_logging(log_level: LogLevel) {
     SimpleLogger::new()
         .with_colors(true)
         .with_level(log_level)

--- a/wolf_engine_core/src/logging.rs
+++ b/wolf_engine_core/src/logging.rs
@@ -2,6 +2,7 @@
 
 use simple_logger::SimpleLogger;
 
+/// Indicates the verbosity of the log system.
 pub enum LogLevel {
     Trace,
     Debug,

--- a/wolf_engine_core/src/logging.rs
+++ b/wolf_engine_core/src/logging.rs
@@ -11,12 +11,11 @@ use simple_logger::SimpleLogger;
 /// # Examples
 ///
 /// To use the default logger, just initialize it by calling this function and providing it with
-/// the desired [LevelFilter].
+/// the desired [LogLevel].
 ///
 /// ```
-/// # use log::LevelFilter;
-/// #
-/// wolf_engine_core::logging::initialize_logging(LevelFilter::Debug);
+/// # use wolf_engine_core::logging:LogLevel;
+/// wolf_engine_core::logging::initialize_logging(LogLevel::Debug);
 /// ```
 ///
 /// Messages are logged using [log] macros.

--- a/wolf_engine_core/src/logging.rs
+++ b/wolf_engine_core/src/logging.rs
@@ -4,12 +4,14 @@ use simple_logger::SimpleLogger;
 
 pub enum LogLevel {
     Debug,
+    Info,
 }
 
 impl Into<log::LevelFilter> for LogLevel {
     fn into(self) -> log::LevelFilter {
         match self {
             Self::Debug => log::LevelFilter::Debug,
+            Self::Info => log::LevelFilter::Info,
         }
     }
 }

--- a/wolf_engine_core/src/logging.rs
+++ b/wolf_engine_core/src/logging.rs
@@ -3,15 +3,23 @@
 use simple_logger::SimpleLogger;
 
 pub enum LogLevel {
+    Trace,
     Debug,
     Info,
+    Warn,
+    Error,
+    Off,
 }
 
 impl Into<log::LevelFilter> for LogLevel {
     fn into(self) -> log::LevelFilter {
         match self {
+            Self::Trace => log::LevelFilter::Trace,
             Self::Debug => log::LevelFilter::Debug,
             Self::Info => log::LevelFilter::Info,
+            Self::Warn => log::LevelFilter::Warn,
+            Self::Error => log::LevelFilter::Error,
+            Self::Off => log::LevelFilter::Off,
         }
     }
 }
@@ -28,7 +36,6 @@ impl Into<log::LevelFilter> for LogLevel {
 ///
 /// ```
 /// # use wolf_engine_core::logging::LogLevel;
-/// wolf_engine_core::logging::initialize_logging(LogLevel::Debug);
 /// ```
 ///
 /// Messages are logged using [log] macros.
@@ -46,3 +53,4 @@ pub fn initialize_logging(log_level: LogLevel) {
         .init()
         .expect("Failed to initialize the logger");
 }
+

--- a/wolf_engine_core/src/logging.rs
+++ b/wolf_engine_core/src/logging.rs
@@ -4,22 +4,21 @@ use simple_logger::SimpleLogger;
 
 /// Indicates the verbosity of the log system.
 pub enum LogLevel {
-
     /// Log all messages.
     Trace,
 
     /// Log debug messages.
     Debug,
-    
+
     /// Log info messages.
     Info,
-    
+
     /// Log warning messages.
     Warn,
 
     /// Log error messages.
     Error,
-    
+
     /// Disable log messages.
     Off,
 }
@@ -66,4 +65,3 @@ pub fn initialize_logging(log_level: LogLevel) {
         .init()
         .expect("Failed to initialize the logger");
 }
-

--- a/wolf_engine_core/src/logging.rs
+++ b/wolf_engine_core/src/logging.rs
@@ -23,15 +23,15 @@ pub enum LogLevel {
     Off,
 }
 
-impl Into<log::LevelFilter> for LogLevel {
-    fn into(self) -> log::LevelFilter {
-        match self {
-            Self::Trace => log::LevelFilter::Trace,
-            Self::Debug => log::LevelFilter::Debug,
-            Self::Info => log::LevelFilter::Info,
-            Self::Warn => log::LevelFilter::Warn,
-            Self::Error => log::LevelFilter::Error,
-            Self::Off => log::LevelFilter::Off,
+impl From<LogLevel> for log::LevelFilter {
+    fn from(value: LogLevel) -> Self {
+        match value {
+            LogLevel::Trace => log::LevelFilter::Trace,
+            LogLevel::Debug => log::LevelFilter::Debug,
+            LogLevel::Info => log::LevelFilter::Info,
+            LogLevel::Warn => log::LevelFilter::Warn,
+            LogLevel::Error => log::LevelFilter::Error,
+            LogLevel::Off => log::LevelFilter::Off,
         }
     }
 }

--- a/wolf_engine_core/src/logging.rs
+++ b/wolf_engine_core/src/logging.rs
@@ -4,11 +4,23 @@ use simple_logger::SimpleLogger;
 
 /// Indicates the verbosity of the log system.
 pub enum LogLevel {
+
+    /// Log all messages.
     Trace,
+
+    /// Log debug messages.
     Debug,
+    
+    /// Log info messages.
     Info,
+    
+    /// Log warning messages.
     Warn,
+
+    /// Log error messages.
     Error,
+    
+    /// Disable log messages.
     Off,
 }
 

--- a/wolf_engine_core/src/logging.rs
+++ b/wolf_engine_core/src/logging.rs
@@ -27,7 +27,7 @@ impl Into<log::LevelFilter> for LogLevel {
 /// the desired [LogLevel].
 ///
 /// ```
-/// # use wolf_engine_core::logging:LogLevel;
+/// # use wolf_engine_core::logging::LogLevel;
 /// wolf_engine_core::logging::initialize_logging(LogLevel::Debug);
 /// ```
 ///

--- a/wolf_engine_core/src/logging.rs
+++ b/wolf_engine_core/src/logging.rs
@@ -6,6 +6,14 @@ pub enum LogLevel {
     Debug,
 }
 
+impl Into<log::LevelFilter> for LogLevel {
+    fn into(self) -> log::LevelFilter {
+        match self {
+            Self::Debug => log::LevelFilter::Debug,
+        }
+    }
+}
+
 /// Initializes the logging system with a pre-configured [SimpleLogger] instance.
 ///
 /// This function is provided for those who don't need a complicated logging setup.  Messages will
@@ -31,7 +39,7 @@ pub enum LogLevel {
 pub fn initialize_logging(log_level: LogLevel) {
     SimpleLogger::new()
         .with_colors(true)
-        .with_level(log_level)
+        .with_level(log_level.into())
         .with_utc_timestamps()
         .init()
         .expect("Failed to initialize the logger");


### PR DESCRIPTION
<!-- Include a quick summary of the changes made in this PR. -->

Because the `intialize_logging` function was "leaking" `log` types through WE's API, it was necessary to import `log` in order to use Wolf Engine's `logging` module.  This PR fixes this by updating `logging::intialize_logging` to use a custom `LogLevel` enum. 

# Change Type 

See [Semantic Versioning](https://semver.org/) for more information.

<!-- Select one (Delete the rest): -->

- Major

# Changes Made

<!-- Planned changes should be done as a checklist, and changes marked off when completed. -->

- [ ] Replaced the `log::LevelFilter` argument of `logging::intialize_logging` with a custom `LogLevel` enum.
- [ ] Added `logging` example to show how to use the `logging` module.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR can be accepted.

- [x] Feature Completeness
  - [x] All planned changes have been completed.
  - [x] New behaviors are covered by tests.
- [x] Code Quality
  - [x] The codebase has been cleaned up and refactored.
  - [x] The codebase is formatted correctly (run `cargo fmt`.)
  - [x] All compiler warnings have been resolved.
  - [x] All Clippy warnings have been resolved (run `cargo clippy`.)
- [x] Documentation
  - [x] The documentation has been updated.
  - [x] Relevant examples have been provided in `/examples`.
  - [x] All doctests / examples are passing.
  - [x] All documentation warnings / errors have been resolved.
- [x] Merge
  - [x] The feature branch has been brought up to date with the main branch (`fetch origin/main && merge origin/main`.)
  - [x] The version number has been bumped.
  - [x] I understand and agree to the contribution guidelines.
