### PR TITLE
Refactor/engine typedef

### DIFF
--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -124,7 +124,7 @@ pub type Engine<D> = (EventLoop, Context<D>);
 /// # use wolf_engine::prelude::*;
 /// let (mut event_loop, mut context) = wolf_engine::init(SomeCustomDataType {});
 /// ```
-pub fn init<D>(data: D) -> (EventLoop, Context<D>) {
+pub fn init<D>(data: D) -> Engine<D> {
     let event_loop = EventLoop::new();
     let context = Context::new(&event_loop, data);
     (event_loop, context)

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -87,6 +87,7 @@ pub mod prelude {
     pub use events::*;
 }
 
+/// Represents the [`EventLoop`]-[`Context`] pair that makes up "the engine."
 pub type Engine<D> = (EventLoop, Context<D>);
 
 /// Initializes a new instance of the [`EventLoop`], and its associated [`Context`], with the

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -87,6 +87,8 @@ pub mod prelude {
     pub use events::*;
 }
 
+pub type Engine<D> = (EventLoop, Context<D>);
+
 /// Initializes a new instance of the [`EventLoop`], and its associated [`Context`], with the
 /// provided data.
 ///


### PR DESCRIPTION
Added an `Engine` type-def to represent the `(EventLoop, Context)` pair.

# Changes Made

All notable changes introduced by this PR should be documented here.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

- Added `Engine<D>` type-def.
- Changed return type of `wolf_engine::init()` to `Engine<D>`.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR
can be accepted.

- [x] New behaviors are covered by tests, and / or examples.
- [x] The documentation has been updated (if applicable.)
- [x] The version number has been bumped (if applicable.)
- [x] The feature branch is up to date with `main`. 
