### PR TITLE
CI: Update, and Replace Broken Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       OPTIONS: ${{ matrix.platform.options }}
     runs-on: ${{ matrix.platform.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable 
@@ -37,7 +37,7 @@ jobs:
     name: Check Code Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable 
@@ -50,7 +50,7 @@ jobs:
     name: Check Clippy Warnings
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - name: Test Workspace on ${{ matrix.platform.os }} 
       with:
         toolchain: stable 
+    - name: Test Workspace on ${{ matrix.platform.os }} 
       shell: bash
       run: cargo test --workspace --verbose $OPTIONS --features=$FEATURES
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       OPTIONS: ${{ matrix.platform.options }}
     runs-on: ${{ matrix.platform.os }}
     steps:
-    - name: Run tests
+    - name: Test Workspace on ${{ matrix.platform.os }} 
       shell: bash
       run: cargo test --workspace --verbose $OPTIONS --features=$FEATURES
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
       OPTIONS: ${{ matrix.platform.options }}
     runs-on: ${{ matrix.platform.os }}
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,7 @@ jobs:
     name: Check Code Format
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable 
@@ -51,8 +50,7 @@ jobs:
     name: Check Clippy Warnings
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
       OPTIONS: ${{ matrix.platform.options }}
     runs-on: ${{ matrix.platform.os }}
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ jobs:
       OPTIONS: ${{ matrix.platform.options }}
     runs-on: ${{ matrix.platform.os }}
     steps:
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Test Workspace on ${{ matrix.platform.os }} 
+      with:
+        toolchain: stable 
       shell: bash
       run: cargo test --workspace --verbose $OPTIONS --features=$FEATURES
 
@@ -35,10 +38,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Setup Rust
-        uses: ATiltedTree/setup-rust@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          rust-version: stable 
+          toolchain: stable 
+          components: rustfmt 
       - name: Check Code Format
         shell: bash
         run: cargo fmt --check 
@@ -49,10 +52,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Setup Rust
-        uses: ATiltedTree/setup-rust@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          rust-version: stable 
+          toolchain: stable 
+          components: clippy
       - name: Check Code Format
         shell: bash
         run: cargo clippy --all-features -- --deny warnings 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,6 @@ jobs:
       OPTIONS: ${{ matrix.platform.options }}
     runs-on: ${{ matrix.platform.os }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Rust
-      uses: ATiltedTree/setup-rust@v1
-      with:
-        rust-version: ${{ matrix.rust-version }} 
     - name: Run tests
       shell: bash
       run: cargo test --workspace --verbose $OPTIONS --features=$FEATURES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
     env:
       RUST_BACKTRACE: 1
       CARGO_TERM_COLOR: always
-      FEATURES: ${{ format(',{0}', matrix.platform.features ) }}
-      OPTIONS: ${{ matrix.platform.options }}
     runs-on: ${{ matrix.platform.os }}
     steps:
     - uses: actions/checkout@v3
@@ -31,7 +29,7 @@ jobs:
         toolchain: stable 
     - name: Test Workspace on ${{ matrix.platform.os }} 
       shell: bash
-      run: cargo test --workspace --verbose $OPTIONS --features=$FEATURES
+      run: cargo test --workspace --verbose --all-features  
 
   check_code_format:
     name: Check Code Format


### PR DESCRIPTION
The [`ATiledTree/setup-rust`](https://github.com/atiltedtree/setup-rust) action has broken on MacOS.  The project doesn't seem to be maintained anymore, so I don't think it will be fixed.

# Changes Made

All notable changes introduced by this PR should be documented here.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

- Changed `checkout` action from `v2` to `v3`.
- Changed [`ATiledTree/setup-rust`](https://github.com/atiltedtree/setup-rust) with [`actions-rust-lang/setup-rust-toolchain`](https://github.com/actions-rust-lang/setup-rust-toolchain) in the `CI` workflow.
- Change name of test action to `Test Workspace on {os}`.
- Changed the test workflow to run with `--all-features` enabled.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR
can be accepted.

- [x] New behaviors are covered by tests, and / or examples.
- [x] The documentation has been updated (if applicable.)
- [x] The version number has been bumped (if applicable.)
- [x] The feature branch is up to date with `main`. 
