### PR TITLE
Remove `Update` and `Render` Events

### DIFF
--- a/examples/core_engine_basics.rs
+++ b/examples/core_engine_basics.rs
@@ -16,21 +16,21 @@ pub fn process_event(event: Event, context: &mut Context<GameData>) {
     match event {
         // Shut down the game.
         Event::Quit => println!("Quit event received.  Goodbye!"),
-        // Update the game.
-        Event::Update => {
-            if context.data.number == 3 {
-                // To shut down the Engine, you must send a quit event.
-                context.quit();
-            } else {
-                context.data.number += 1;
-            }
-        }
-        Event::Render => println!("{}", context.data.number),
         Event::EventsCleared => {
-            // Note: The engine will not emit Update / Render events on it's own.
-            //       You are expected to do this yourself.
-            context.update();
-            context.render();
+            // Update the game.
+            {
+                if context.data.number == 3 {
+                    // To shut down the Engine, you must send a quit event.
+                    context.quit();
+                } else {
+                    context.data.number += 1;
+                }
+            }
+
+            // Display the game.
+            {
+                println!("{}", context.data.number);
+            }
         }
         _ => (),
     }

--- a/examples/core_engine_basics.rs
+++ b/examples/core_engine_basics.rs
@@ -14,24 +14,24 @@ pub fn main() {
 
 pub fn process_event(event: Event, context: &mut Context<GameData>) {
     match event {
+        Event::EventsCleared => {
+            update(context);
+            display(context);
+        }
         // Shut down the game.
         Event::Quit => println!("Quit event received.  Goodbye!"),
-        Event::EventsCleared => {
-            // Update the game.
-            {
-                if context.data.number == 3 {
-                    // To shut down the Engine, you must send a quit event.
-                    context.quit();
-                } else {
-                    context.data.number += 1;
-                }
-            }
-
-            // Display the game.
-            {
-                println!("{}", context.data.number);
-            }
-        }
         _ => (),
     }
+}
+
+pub fn update(context: &mut Context<GameData>) {
+    if context.data.number == 3 {
+        context.quit();
+    } else {
+        context.data.number += 1;
+    }
+}
+
+pub fn display(context: &mut Context<GameData>) {
+    println!("{}", context.data.number);
 }

--- a/examples/core_engine_basics.rs
+++ b/examples/core_engine_basics.rs
@@ -18,7 +18,6 @@ pub fn process_event(event: Event, context: &mut Context<GameData>) {
             update(context);
             display(context);
         }
-        // Shut down the game.
         Event::Quit => println!("Quit event received.  Goodbye!"),
         _ => (),
     }

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -69,14 +69,6 @@ impl<D> Context<D> {
     pub fn quit(&self) {
         self.event_sender.send_event(Event::Quit).ok();
     }
-
-    pub fn update(&self) {
-        self.event_sender.send_event(Event::Update).ok();
-    }
-
-    pub fn render(&self) {
-        self.event_sender.send_event(Event::Render).ok();
-    }
 }
 
 impl<D> HasEventSender<Event> for Context<D> {

--- a/wolf_engine_core/src/event_loop.rs
+++ b/wolf_engine_core/src/event_loop.rs
@@ -99,14 +99,12 @@ mod event_loop_tests {
 
     struct TestData {
         updates: i32,
-        renders: i32,
     }
 
     impl TestData {
         pub fn new() -> Self {
             Self {
                 updates: 0,
-                renders: 0,
             }
         }
     }
@@ -122,7 +120,6 @@ mod event_loop_tests {
 
         assert!(event_loop.has_quit);
         assert_eq!(context.data.updates, 3);
-        assert_eq!(context.data.renders, 3);
     }
 
     fn process_event(event: Event, context: &mut Context<TestData>) {

--- a/wolf_engine_core/src/event_loop.rs
+++ b/wolf_engine_core/src/event_loop.rs
@@ -128,37 +128,19 @@ mod event_loop_tests {
     fn process_event(event: Event, context: &mut Context<TestData>) {
         match event {
             Event::Quit => (),
-            Event::Update => {
-                if context.data.updates < 3 && context.data.renders < 3 {
-                    context.data.updates += 1;
-                } else {
-                    context.quit();
-                }
-            }
-            Event::Render => context.data.renders += 1,
-            Event::EventsCleared => {
-                context.update();
-                context.render();
-            }
+            Event::EventsCleared => {}
             _ => (),
         }
     }
+}
 
-    #[test]
-    fn should_emit_events_cleared_when_event_queue_is_empty() {
-        let (mut event_loop, context) = crate::init(());
+#[test]
+fn should_emit_events_cleared_when_event_queue_is_empty() {
+    let (mut event_loop, context) = crate::init(());
 
-        context.event_sender().send_event(Event::Update).ok();
-
-        assert_eq!(
-            event_loop.next_event().unwrap(),
-            Event::Update,
-            "The event-loop did not emit the previously sent Update event."
-        );
-        assert_eq!(
-            event_loop.next_event().unwrap(),
-            Event::EventsCleared,
-            "The event-loop did not emit the expected EventsCleared event."
-        );
-    }
+    assert_eq!(
+        event_loop.next_event().unwrap(),
+        Event::EventsCleared,
+        "The event-loop did not emit the expected EventsCleared event."
+    );
 }

--- a/wolf_engine_core/src/event_loop.rs
+++ b/wolf_engine_core/src/event_loop.rs
@@ -103,9 +103,7 @@ mod event_loop_tests {
 
     impl TestData {
         pub fn new() -> Self {
-            Self {
-                updates: 0,
-            }
+            Self { updates: 0 }
         }
     }
 

--- a/wolf_engine_core/src/event_loop.rs
+++ b/wolf_engine_core/src/event_loop.rs
@@ -139,7 +139,6 @@ fn should_emit_events_cleared_when_event_queue_is_empty() {
     let (mut event_loop, context) = crate::init(());
 
     context.event_sender().send_event(Event::Test).ok();
-
     assert_eq!(
         event_loop.next_event().unwrap(),
         Event::Test,

--- a/wolf_engine_core/src/event_loop.rs
+++ b/wolf_engine_core/src/event_loop.rs
@@ -138,9 +138,18 @@ mod event_loop_tests {
 fn should_emit_events_cleared_when_event_queue_is_empty() {
     let (mut event_loop, context) = crate::init(());
 
+    context.event_sender().send_event(Event::Test).ok();
+
+    assert_eq!(
+        event_loop.next_event().unwrap(),
+        Event::Test,
+        "The event-loop did not emit the expected Test event."
+    );
+
     assert_eq!(
         event_loop.next_event().unwrap(),
         Event::EventsCleared,
         "The event-loop did not emit the expected EventsCleared event."
     );
+}
 }

--- a/wolf_engine_core/src/event_loop.rs
+++ b/wolf_engine_core/src/event_loop.rs
@@ -122,13 +122,19 @@ mod event_loop_tests {
 
         assert!(event_loop.has_quit);
         assert_eq!(context.data.updates, 3);
-        assert_eq!(context.data.renders, 4);
+        assert_eq!(context.data.renders, 3);
     }
 
     fn process_event(event: Event, context: &mut Context<TestData>) {
         match event {
             Event::Quit => (),
-            Event::EventsCleared => {}
+            Event::EventsCleared => {
+                if context.data.updates == 3 {
+                    context.quit();
+                } else {
+                    context.data.updates += 1;
+                }
+            }
             _ => (),
         }
     }

--- a/wolf_engine_core/src/event_loop.rs
+++ b/wolf_engine_core/src/event_loop.rs
@@ -152,4 +152,3 @@ fn should_emit_events_cleared_when_event_queue_is_empty() {
         "The event-loop did not emit the expected EventsCleared event."
     );
 }
-}

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -17,6 +17,10 @@ pub enum Event {
 
     /// A [`WindowEvent`] emitted by the window system.
     WindowEvent(WindowEvent),
+
+    #[cfg(test)]
+    /// A test event only used by unit tests.
+    Test,
 }
 
 #[cfg(test)]

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -10,12 +10,6 @@ pub enum Event {
     /// Emitted when the engine should quit.
     Quit,
 
-    /// Indicates the engine should update game logic.
-    Update,
-
-    /// Indicates the engine should render the game.
-    Render,
-
     /// Indicates the end of a frame.
     ///
     /// `EventsCleared` should be emitted only after all other events have been processed.
@@ -31,14 +25,14 @@ mod event_tests {
 
     #[test]
     fn should_implement_clone() {
-        let event = Event::Update;
+        let event = Event::EventsCleared;
         let clone = event.clone();
         assert_eq!(event, clone);
     }
 
     #[test]
     fn should_implement_copy() {
-        let event = Event::Update;
+        let event = Event::EventsCleared;
         let copy = copy_test(event);
         assert_eq!(event, copy);
     }

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -38,24 +38,15 @@
 //! pub fn process_event(event: Event, context: &mut Context<GameData>) {
 //!     match event {
 //!         // Indicates there are no more events on the queue, or, essentially, the end of the
-//!         // current frame.
+//!         // current frame.  You should put most of your game logic here.
 //!         Event::EventsCleared => {
-//!             // Note: The engine will not emit Update / Render events on it's own.
-//!             //       You are expected to do this yourself.
-//!             context.update();
-//!             context.render();
-//!         }
-//!         // Update the game's state.
-//!         Event::Update => {
 //!             if context.data.number == 3 {
-//!                 // To shut down the Engine, you must send a quit event.
 //!                 context.quit();
 //!             } else {
 //!                 context.data.number += 1;
 //!             }
+//!             println!("{}", context.data.number);
 //!         }
-//!         // Render, or display the game's state.
-//!         Event::Render => println!("{}", context.data.number),
 //!         // Shut down the game.
 //!         Event::Quit => println!("Quit event received.  Goodbye!"),
 //!         _ => (),


### PR DESCRIPTION
I've removed the `Update`, and `Render` events because they're causing issues with order of operations, leading to incorrect behavior that's difficult to fix.  Running game code on `EventsCleared` solves the issues, so I've adjusted accordingly.

# Changes Made

All notable changes introduced by this PR should be documented here.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

- Removed `Event::Update`.
- Removed `Event::Render`.
- Changed update, and render logic to run on `EventsCleared` instead of `Update`, and `Render`.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR
can be accepted.

- [x] New behaviors are covered by tests, and / or examples.
- [x] The documentation has been updated (if applicable.)
- [x] The version number has been bumped (if applicable.)
- [x] The feature branch is up to date with `main`. 
