### PR TITLE
Feature: User-Defined Events (Part 2)

### DIFF
--- a/examples/core_engine_basics.rs
+++ b/examples/core_engine_basics.rs
@@ -12,7 +12,7 @@ pub fn main() {
     }
 }
 
-pub fn process_event(event: Event, context: &mut Context<GameData>) {
+pub fn process_event(event: Event<()>, context: &mut Context<GameData, ()>) {
     match event {
         Event::EventsCleared => {
             update(context);
@@ -23,7 +23,7 @@ pub fn process_event(event: Event, context: &mut Context<GameData>) {
     }
 }
 
-pub fn update(context: &mut Context<GameData>) {
+pub fn update(context: &mut Context<GameData, ()>) {
     if context.data.number == 3 {
         context.quit();
     } else {
@@ -31,6 +31,6 @@ pub fn update(context: &mut Context<GameData>) {
     }
 }
 
-pub fn display(context: &mut Context<GameData>) {
+pub fn display(context: &mut Context<GameData, ()>) {
     println!("{}", context.data.number);
 }

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -21,7 +21,7 @@ use crate::events::*;
 ///
 /// ```
 /// # use wolf_engine_core as wolf_engine;
-/// let (mut event_loop, mut context) = wolf_engine::init(());
+/// let (mut event_loop, mut context) = wolf_engine::init::<(), ()>(());
 /// ```
 ///
 /// ## Context Data
@@ -49,7 +49,7 @@ use crate::events::*;
 /// # }
 ///
 /// // Initialize the engine with your custom data.
-/// let (mut event_loop, mut context) = wolf_engine::init(CustomContextData::new());
+/// let (mut event_loop, mut context) = wolf_engine::init::<CustomContextData, ()>(CustomContextData::new());
 /// ```
 pub struct Context<D,E: UserEvent> {
     /// The user-facing engine data.  Normally things like subsystems.

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -51,13 +51,13 @@ use crate::events::*;
 /// // Initialize the engine with your custom data.
 /// let (mut event_loop, mut context) = wolf_engine::init(CustomContextData::new());
 /// ```
-pub struct Context<D,E> {
+pub struct Context<D,E: UserEvent> {
     /// The user-facing engine data.  Normally things like subsystems.
     pub data: D,
     event_sender: Arc<dyn EventSender<Event<E>>>,
 }
 
-impl<D,E> Context<D,E> {
+impl<D,E: UserEvent> Context<D,E> {
     /// Create a new `Context` from the provided [`EventQueue`] and data.
     pub(crate) fn new(event_queue: &dyn EventQueue<Event<E>>, data: D) -> Self {
         Self {
@@ -71,7 +71,7 @@ impl<D,E> Context<D,E> {
     }
 }
 
-impl<D,E> HasEventSender<Event<E>> for Context<D,E> {
+impl<D,E: UserEvent> HasEventSender<Event<E>> for Context<D,E> {
     fn event_sender(&self) -> Arc<dyn EventSender<Event<E>>> {
         self.event_sender.clone()
     }

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -51,13 +51,13 @@ use crate::events::*;
 /// // Initialize the engine with your custom data.
 /// let (mut event_loop, mut context) = wolf_engine::init::<CustomContextData, ()>(CustomContextData::new());
 /// ```
-pub struct Context<D,E: UserEvent> {
+pub struct Context<D, E: UserEvent> {
     /// The user-facing engine data.  Normally things like subsystems.
     pub data: D,
     event_sender: Arc<dyn EventSender<Event<E>>>,
 }
 
-impl<D,E: UserEvent> Context<D,E> {
+impl<D, E: UserEvent> Context<D, E> {
     /// Create a new `Context` from the provided [`EventQueue`] and data.
     pub(crate) fn new(event_queue: &dyn EventQueue<Event<E>>, data: D) -> Self {
         Self {
@@ -71,7 +71,7 @@ impl<D,E: UserEvent> Context<D,E> {
     }
 }
 
-impl<D,E: UserEvent> HasEventSender<Event<E>> for Context<D,E> {
+impl<D, E: UserEvent> HasEventSender<Event<E>> for Context<D, E> {
     fn event_sender(&self) -> Arc<dyn EventSender<Event<E>>> {
         self.event_sender.clone()
     }

--- a/wolf_engine_core/src/event_loop.rs
+++ b/wolf_engine_core/src/event_loop.rs
@@ -139,10 +139,10 @@ mod event_loop_tests {
 fn should_emit_events_cleared_when_event_queue_is_empty() {
     let (mut event_loop, context) = crate::init::<(), ()>(());
 
-    context.event_sender().send_event(Event::Test).ok();
+    context.event_sender().send_event(Event::UserDefined(())).ok();
     assert_eq!(
         event_loop.next_event().unwrap(),
-        Event::Test,
+        Event::UserDefined(()),
         "The event-loop did not emit the expected Test event."
     );
 

--- a/wolf_engine_core/src/event_loop.rs
+++ b/wolf_engine_core/src/event_loop.rs
@@ -25,7 +25,7 @@ use crate::events::*;
 ///
 /// ```
 /// # use wolf_engine_core as wolf_engine;
-/// let (mut event_loop, mut context) = wolf_engine::init(());
+/// let (mut event_loop, mut context) = wolf_engine::init::<(), ()>(());
 /// ```
 ///
 /// ## Responding to Events
@@ -36,7 +36,7 @@ use crate::events::*;
 /// # use wolf_engine_core as wolf_engine;
 /// # use wolf_engine::prelude::*;
 /// #
-/// # let (mut event_loop, mut context) = wolf_engine::init(());
+/// # let (mut event_loop, mut context) = wolf_engine::init::<(), ()>(());
 /// #
 /// while let Some(event) = event_loop.next_event() {
 ///     match event {

--- a/wolf_engine_core/src/event_loop.rs
+++ b/wolf_engine_core/src/event_loop.rs
@@ -46,12 +46,12 @@ use crate::events::*;
 /// #   break;
 /// }
 /// ```
-pub struct EventLoop<E> {
+pub struct EventLoop<E: UserEvent> {
     event_queue: MpscEventQueue<Event<E>>,
     has_quit: bool,
 }
 
-impl<E> EventLoop<E> {
+impl<E: UserEvent> EventLoop<E> {
     pub(crate) fn new() -> Self {
         let event_queue = MpscEventQueue::new();
         Self {
@@ -76,7 +76,7 @@ impl<E> EventLoop<E> {
     }
 }
 
-impl<E> EventQueue<Event<E>> for EventLoop<E> {
+impl<E: UserEvent> EventQueue<Event<E>> for EventLoop<E> {
     fn next_event(&mut self) -> Option<Event<E>> {
         match self.event_queue.next_event() {
             Some(event) => Some(self.handle_event(event)),
@@ -85,7 +85,7 @@ impl<E> EventQueue<Event<E>> for EventLoop<E> {
     }
 }
 
-impl<E> HasEventSender<Event<E>> for EventLoop<E> {
+impl<E: UserEvent> HasEventSender<Event<E>> for EventLoop<E> {
     fn event_sender(&self) -> Arc<dyn EventSender<Event<E>>> {
         self.event_queue.event_sender()
     }
@@ -120,7 +120,7 @@ mod event_loop_tests {
         assert_eq!(context.data.updates, 3);
     }
 
-    fn process_event<E>(event: Event<E>, context: &mut Context<TestData,E>) {
+    fn process_event<E: UserEvent>(event: Event<E>, context: &mut Context<TestData,E>) {
         match event {
             Event::Quit => (),
             Event::EventsCleared => {

--- a/wolf_engine_core/src/event_loop.rs
+++ b/wolf_engine_core/src/event_loop.rs
@@ -120,7 +120,7 @@ mod event_loop_tests {
         assert_eq!(context.data.updates, 3);
     }
 
-    fn process_event<E: UserEvent>(event: Event<E>, context: &mut Context<TestData,E>) {
+    fn process_event<E: UserEvent>(event: Event<E>, context: &mut Context<TestData, E>) {
         match event {
             Event::Quit => (),
             Event::EventsCleared => {
@@ -139,7 +139,10 @@ mod event_loop_tests {
 fn should_emit_events_cleared_when_event_queue_is_empty() {
     let (mut event_loop, context) = crate::init::<(), ()>(());
 
-    context.event_sender().send_event(Event::UserDefined(())).ok();
+    context
+        .event_sender()
+        .send_event(Event::UserDefined(()))
+        .ok();
     assert_eq!(
         event_loop.next_event().unwrap(),
         Event::UserDefined(()),

--- a/wolf_engine_core/src/event_loop.rs
+++ b/wolf_engine_core/src/event_loop.rs
@@ -110,7 +110,7 @@ mod event_loop_tests {
     #[test]
     #[timeout(100)]
     fn should_run_and_quit() {
-        let (mut event_loop, mut context) = crate::init(TestData::new());
+        let (mut event_loop, mut context) = crate::init::<TestData, ()>(TestData::new());
 
         while let Some(event) = event_loop.next_event() {
             process_event(event, &mut context);
@@ -137,7 +137,7 @@ mod event_loop_tests {
 
 #[test]
 fn should_emit_events_cleared_when_event_queue_is_empty() {
-    let (mut event_loop, context) = crate::init(());
+    let (mut event_loop, context) = crate::init::<(), ()>(());
 
     context.event_sender().send_event(Event::Test).ok();
     assert_eq!(

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -23,10 +23,6 @@ pub enum Event<E: UserEvent> {
     WindowEvent(WindowEvent),
 
     UserDefined(E),
-
-    #[cfg(test)]
-    /// A test event only used by unit tests.
-    Test,
 }
 
 #[cfg(test)]

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -45,7 +45,7 @@ mod event_tests {
         assert_eq!(event, copy);
     }
 
-    fn copy_test<E>(event: Event<E>) -> Event<E> {
+    fn copy_test<E: UserEvent>(event: Event<E>) -> Event<E> {
         event
     }
 

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -5,6 +5,8 @@ pub enum WindowEvent {}
 
 pub trait UserEvent {}
 
+impl<T> UserEvent for T {}
+
 /// Provides the main events used by Wolf Engine.
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -3,10 +3,12 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum WindowEvent {}
 
+pub trait UserEvent {}
+
 /// Provides the main events used by Wolf Engine.
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum Event<E> {
+pub enum Event<E: UserEvent> {
     /// Emitted when the engine should quit.
     Quit,
 

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -3,9 +3,9 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum WindowEvent {}
 
-pub trait UserEvent: PartialEq + 'static {}
+pub trait UserEvent: PartialEq + Clone + Copy + 'static {}
 
-impl<T> UserEvent for T where T: PartialEq + 'static {}
+impl<T> UserEvent for T where T: PartialEq + Clone + Copy + 'static {}
 
 /// Provides the main events used by Wolf Engine.
 #[non_exhaustive]

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -3,9 +3,9 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum WindowEvent {}
 
-pub trait UserEvent {}
+pub trait UserEvent: PartialEq + 'static {}
 
-impl<T> UserEvent for T {}
+impl<T> UserEvent for T where T: PartialEq + 'static {}
 
 /// Provides the main events used by Wolf Engine.
 #[non_exhaustive]

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! pub fn main() {
 //!     // Start by initializing the engine's Event-Loop, and Context.
-//!     let (mut event_loop, mut context) = wolf_engine::init(GameData { number: 0 });
+//!     let (mut event_loop, mut context) = wolf_engine::init::<GameData, ()>(GameData { number: 0 });
 //!     
 //!     // The Event-Loop will continue to return events, every call, until a Quit event is sent,
 //!     // only then, will the Event-Loop will return None.
@@ -35,7 +35,7 @@
 //!     }
 //! }
 //!
-//! pub fn process_event(event: Event, context: &mut Context<GameData>) {
+//! pub fn process_event(event: Event<()>, context: &mut Context<GameData, ()>) {
 //!     match event {
 //!         // Indicates there are no more events on the queue, or, essentially, the end of the
 //!         // current frame.  You should put most of your game logic here.
@@ -96,7 +96,7 @@ pub type Engine<D,E> = (EventLoop<E>, Context<D,E>);
 ///
 /// // Start by initializing the EventLoop, and Context.
 /// // In this case, we are not using any Context data, so `()` is used.
-/// let (mut event_loop, mut context) = wolf_engine::init(());
+/// let (mut event_loop, mut context) = wolf_engine::init::<(), ()>(());
 ///
 /// // Then, you can use the EventLoop to run your game's main-loop.
 /// while let Some(event) = event_loop.next_event() {
@@ -115,7 +115,7 @@ pub type Engine<D,E> = (EventLoop<E>, Context<D,E>);
 /// # pub struct SomeCustomDataType {};
 /// #
 /// # use wolf_engine::prelude::*;
-/// let (mut event_loop, mut context) = wolf_engine::init(SomeCustomDataType {});
+/// let (mut event_loop, mut context) = wolf_engine::init::<SomeCustomDataType, ()>(SomeCustomDataType {});
 /// ```
 pub fn init<D,E: UserEvent>(data: D) -> Engine<D,E> {
     let event_loop = EventLoop::new();

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -81,7 +81,7 @@ pub mod prelude {
 use events::UserEvent;
 
 /// Represents the [`EventLoop`]-[`Context`] pair that makes up "the engine."
-pub type Engine<D,E> = (EventLoop<E>, Context<D,E>);
+pub type Engine<D, E> = (EventLoop<E>, Context<D, E>);
 
 /// Initializes a new instance of the [`EventLoop`], and its associated [`Context`], with the
 /// provided data.
@@ -117,7 +117,7 @@ pub type Engine<D,E> = (EventLoop<E>, Context<D,E>);
 /// # use wolf_engine::prelude::*;
 /// let (mut event_loop, mut context) = wolf_engine::init::<SomeCustomDataType, ()>(SomeCustomDataType {});
 /// ```
-pub fn init<D,E: UserEvent>(data: D) -> Engine<D,E> {
+pub fn init<D, E: UserEvent>(data: D) -> Engine<D, E> {
     let event_loop = EventLoop::new();
     let context = Context::new(&event_loop, data);
     (event_loop, context)

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -78,6 +78,8 @@ pub mod prelude {
     pub use events::*;
 }
 
+use events::UserEvent;
+
 /// Represents the [`EventLoop`]-[`Context`] pair that makes up "the engine."
 pub type Engine<D,E> = (EventLoop<E>, Context<D,E>);
 
@@ -115,7 +117,7 @@ pub type Engine<D,E> = (EventLoop<E>, Context<D,E>);
 /// # use wolf_engine::prelude::*;
 /// let (mut event_loop, mut context) = wolf_engine::init(SomeCustomDataType {});
 /// ```
-pub fn init<D,E>(data: D) -> Engine<D,E> {
+pub fn init<D,E: UserEvent>(data: D) -> Engine<D,E> {
     let event_loop = EventLoop::new();
     let context = Context::new(&event_loop, data);
     (event_loop, context)


### PR DESCRIPTION
This PR is a continuation of #116 (which was merged into this feature branch so I could take over development.)  

It adds User-Defined events, allowing games to define custom events which can be sent through Wolf Engine's `EventLoop`.

Closes issue #113.

# Changes Made

All notable changes introduced by this PR should be documented here.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

- Added `UserEvent` trait.
- Added generic parameter (`E: UserEvent`) to the Event enum.
- Added UserDefined variant to the Event enum.
- Changed `wolf_engine::init()` to add `E: UserEvent` type parameter.
- Changed `Context` to add `E: UserEvent` type parameter.
- Changed `EventLoop` to add `E: UserEvent` type parameter.
- Removed `Event::Test` variant from the `Event` enum.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR
can be accepted.

- [x] New behaviors are covered by tests, and / or examples.
- [x] The documentation has been updated (if applicable.)
- [x] The version number has been bumped (if applicable.)
- [x] The feature branch is up to date with `main`. 
