### PR TITLE
Renamed `EngineEventSender` to `MainEventSender`

### DIFF
--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -10,7 +10,7 @@ fn log_message(#[resource] message: &Message) {
 #[wolf_engine::ecs::system]
 fn quit_after_3_updates(
     #[state] updates: &mut u32,
-    #[resource] event_sender: &EngineEventSender<()>,
+    #[resource] event_sender: &MainEventSender<()>,
 ) {
     if *updates == 3 {
         event_sender.send_event(Event::Quit).ok();

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -7,7 +7,7 @@ use super::EventSender;
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum WindowEvent {}
 
-pub type EngineEventSender<E> = Arc<dyn EventSender<Event<E>>>;
+pub type MainEventSender<E> = Arc<dyn EventSender<Event<E>>>;
 
 /// A user-defined [`Event`] type.
 pub trait UserEvent: PartialEq + Clone + Copy + 'static {}

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -7,7 +7,7 @@ use super::EventSender;
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum WindowEvent {}
 
-/// An alias to the main [`EventSender`] type associated with the [`EventLoop`](crate::EventLoop). 
+/// An alias to the main [`EventSender`] type associated with the [`EventLoop`](crate::EventLoop).
 pub type MainEventSender<E> = Arc<dyn EventSender<Event<E>>>;
 
 /// A user-defined [`Event`] type.

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -7,6 +7,8 @@ use super::EventSender;
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum WindowEvent {}
 
+/// An alias to the main [`EventSender`] associated with the current [`EventLoop`].  To make it
+/// easier to access.
 pub type MainEventSender<E> = Arc<dyn EventSender<Event<E>>>;
 
 /// A user-defined [`Event`] type.

--- a/wolf_engine_core/src/events/engine_events.rs
+++ b/wolf_engine_core/src/events/engine_events.rs
@@ -7,8 +7,7 @@ use super::EventSender;
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum WindowEvent {}
 
-/// An alias to the main [`EventSender`] associated with the current [`EventLoop`].  To make it
-/// easier to access.
+/// An alias to the main [`EventSender`] type associated with the [`EventLoop`](crate::EventLoop). 
 pub type MainEventSender<E> = Arc<dyn EventSender<Event<E>>>;
 
 /// A user-defined [`Event`] type.

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -174,7 +174,7 @@ pub fn init<E: UserEvent>() -> EngineBuilder<E> {
 
 #[cfg(test)]
 mod init_tests {
-    use crate::events::EngineEventSender;
+    use crate::events::MainEventSender;
 
     #[test]
     fn should_use_builder_pattern() {
@@ -204,7 +204,7 @@ mod init_tests {
         let (_event_loop, context) = crate::init::<()>().build();
         let _event_sender = context
             .resources()
-            .get_mut::<EngineEventSender<()>>()
+            .get_mut::<MainEventSender<()>>()
             .expect("No event sender was added.");
     }
 


### PR DESCRIPTION
Renamed `EngineEventSender` to `MainEventSender`, because I think it's a better name.  I've also documented this type, because the docs were missing.

# Changes Made

All notable changes introduced by this PR should be documented here.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

- Renamed `EngineEventSender` to `MainEventSender`.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR
can be accepted.

- [x] New behaviors are covered by tests, and / or examples.
- [x] The documentation has been updated (if applicable.)
- [x] The version number has been bumped (if applicable.)
- [ ] The feature branch is up to date with `main`. 
