### PR TITLE
Remove Update, and Render Schedules from the Context

### DIFF
--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -1,4 +1,5 @@
 use wolf_engine::prelude::*;
+use wolf_engine::ecs::Schedule;
 
 pub struct Message(&'static str);
 
@@ -28,7 +29,7 @@ pub fn main() {
         })
         .build();
 
-    let mut schedule = wolf_engine::ecs::Schedule::builder();
+    let mut schedule = Schedule::builder();
     schedule
         .add_thread_local(log_message_system())
         .add_thread_local(quit_after_3_updates_system(1));

--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -42,7 +42,7 @@ pub fn main() {
 pub fn process_event(event: Event<()>, context: &mut Context<()>, schedule: &mut Schedule) {
     match event {
         Event::EventsCleared => {
-            context.update();
+            context.run_schedule(schedule);
         }
         Event::Quit => log::info!("Quit event received.  Goodbye!"),
         _ => (),

--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -1,5 +1,4 @@
 use wolf_engine::prelude::*;
-use wolf_engine::ecs::Schedule;
 
 pub struct Message(&'static str);
 

--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -29,17 +29,17 @@ pub fn main() {
         })
         .build();
 
-    let mut schedule = Schedule::builder();
-    schedule
+    let mut schedule = Schedule::builder()
         .add_thread_local(log_message_system())
-        .add_thread_local(quit_after_3_updates_system(1));
+        .add_thread_local(quit_after_3_updates_system(1))
+        .build();
 
     while let Some(event) = event_loop.next_event() {
-        process_event(event, &mut context);
+        process_event(event, &mut context, &mut schedule);
     }
 }
 
-pub fn process_event(event: Event<()>, context: &mut Context<()>) {
+pub fn process_event(event: Event<()>, context: &mut Context<()>, schedule: &mut Schedule) {
     match event {
         Event::EventsCleared => {
             context.update();

--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -26,12 +26,12 @@ pub fn main() {
         .with_resources(|resources| {
             resources.add_resource(Message("Hello, World!"));
         })
-        .with_update_schedule(|schedule| {
-            schedule
-                .add_thread_local(log_message_system())
-                .add_thread_local(quit_after_3_updates_system(1));
-        })
         .build();
+
+    let mut schedule = wolf_engine::ecs::Schedule::builder();
+    schedule
+        .add_thread_local(log_message_system())
+        .add_thread_local(quit_after_3_updates_system(1));
 
     while let Some(event) = event_loop.next_event() {
         process_event(event, &mut context);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ pub mod window {
 pub mod prelude {
     pub use super::*;
 
+    pub use ecs::prelude::*;
+
     #[cfg(feature = "framework")]
     pub use framework::*;
 }

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -102,9 +102,7 @@ mod context_tests {
             })
             .build();
 
-        let mut schedule = Schedule::builder()
-            .add_system(add_1_system())
-            .build();
+        let mut schedule = Schedule::builder().add_system(add_1_system()).build();
 
         assert_eq!(*context.resources().get::<i32>().unwrap(), 0);
         context.run_schedule(&mut schedule);

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -111,16 +111,6 @@ impl ContextBuilder {
         self
     }
 
-    pub fn with_update_schedule(mut self, schedule: Schedule) -> Self {
-        self.update_schedule = schedule;
-        self
-    }
-
-    pub fn with_render_schedule(mut self, schedule: Schedule) -> Self {
-        self.render_schedule = schedule;
-        self
-    }
-
     pub fn build<E: UserEvent>(self, event_loop: &EventLoop<E>) -> Context<E> {
         Context {
             world: self.world,

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -91,6 +91,8 @@ impl ContextBuilder {
 
 #[cfg(test)]
 mod context_tests {
+    use legion::Schedule;
+
     #[test]
     fn should_run_ecs_tick() {
         #[legion::system]
@@ -103,10 +105,14 @@ mod context_tests {
             })
             .build();
 
+        let mut schedule = Schedule::builder()
+            .add_system(add_1_system())
+            .build();
+
         assert_eq!(*context.resources().get::<i32>().unwrap(), 0);
-        context.update();
+        context.run_schedule(&mut schedule);
         assert_eq!(*context.resources().get::<i32>().unwrap(), 1);
-        context.render();
+        context.run_schedule(&mut schedule);
         assert_eq!(*context.resources().get::<i32>().unwrap(), 2);
     }
 

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -27,13 +27,6 @@ impl<E: UserEvent> Context<E> {
         schedule.execute(&mut self.world, &mut self.resources);
     }
 
-    pub fn update(&mut self) {
-    }
-
-    /// Runs a single iteration of the Render Schedule.
-    pub fn render(&mut self) {
-    }
-
     /// Returns an immutable reference to the world.
     pub fn world(&self) -> &World {
         &self.world

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -144,12 +144,6 @@ mod context_tests {
             .with_resources(|resources| {
                 resources.add_resource(0);
             })
-            .with_update_schedule(|schedule| {
-                schedule.add_system(add_1_system());
-            })
-            .with_render_schedule(|schedule| {
-                schedule.add_system(add_1_system());
-            })
             .build();
 
         assert_eq!(*context.resources().get::<i32>().unwrap(), 0);

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -14,8 +14,6 @@ use crate::EventLoop;
 pub struct Context<E: UserEvent> {
     world: World,
     resources: Resources,
-    update_schedule: Schedule,
-    render_schedule: Schedule,
     event_sender: Arc<dyn EventSender<Event<E>>>,
 }
 
@@ -57,26 +55,6 @@ impl<E: UserEvent> Context<E> {
         &mut self.resources
     }
 
-    /// Returns an immutable reference to the update schedule.
-    pub fn update_schedule(&self) -> &Schedule {
-        &self.update_schedule
-    }
-
-    /// Returns a mutable reference to the update schedule.
-    pub fn update_schedule_mut(&mut self) -> &mut Schedule {
-        &mut self.update_schedule
-    }
-
-    /// Returns an immutable reference to the render schedule.
-    pub fn render_schedule(&self) -> &Schedule {
-        &self.render_schedule
-    }
-
-    /// Returns a mutable reference to the render schedule.
-    pub fn render_schedule_mut(&mut self) -> &mut Schedule {
-        &mut self.render_schedule
-    }
-
     /// Sends a [Quit Event](Event::Quit) to trigger an engine shutdown.
     pub fn quit(&self) {
         self.event_sender.send_event(Event::Quit).ok();
@@ -92,8 +70,6 @@ impl<E: UserEvent> HasEventSender<Event<E>> for Context<E> {
 pub(crate) struct ContextBuilder {
     world: World,
     resources: Resources,
-    update_schedule: Schedule,
-    render_schedule: Schedule,
 }
 
 impl ContextBuilder {
@@ -101,8 +77,6 @@ impl ContextBuilder {
         Self {
             world: Default::default(),
             resources: Default::default(),
-            update_schedule: Schedule::builder().build(),
-            render_schedule: Schedule::builder().build(),
         }
     }
 
@@ -115,8 +89,6 @@ impl ContextBuilder {
         Context {
             world: self.world,
             resources: self.resources,
-            update_schedule: self.update_schedule,
-            render_schedule: self.render_schedule,
             event_sender: event_loop.event_sender(),
         }
     }

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -23,16 +23,11 @@ impl<E: UserEvent> Context<E> {
         ContextBuilder::new()
     }
 
-    /// Runs a single iteration of the Update Schedule.
     pub fn update(&mut self) {
-        self.update_schedule
-            .execute(&mut self.world, &mut self.resources);
     }
 
     /// Runs a single iteration of the Render Schedule.
     pub fn render(&mut self) {
-        self.render_schedule
-            .execute(&mut self.world, &mut self.resources);
     }
 
     /// Returns an immutable reference to the world.

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -23,6 +23,10 @@ impl<E: UserEvent> Context<E> {
         ContextBuilder::new()
     }
 
+    pub fn run_schedule(&mut self, schedule: &mut Schedule) {
+        schedule.execute(&mut self.world, &mut self.resources);
+    }
+
     pub fn update(&mut self) {
     }
 

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -165,14 +165,10 @@ mod context_tests {
         {
             let _world = context.world();
             let _resources = context.resources();
-            let _update_schedule = context.update_schedule();
-            let _render_schedule = context.render_schedule();
         }
         {
             let _world_mut = context.world_mut();
             let _mut_resources = context.resources_mut();
-            let _update_schedule = context.update_schedule_mut();
-            let _render_schedule = context.render_schedule_mut();
         }
     }
 }

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -76,9 +76,6 @@ pub mod ecs {
         pub use super::system;
     }
 
-    /// A, more clearly-named, alias to [`systems::Builder`].
-    pub type ScheduleBuidler = legion::systems::Builder;
-
     /// Provides a builder-pattern for creating [`Resources`].
     #[derive(Default)]
     pub struct ResourcesBuilder {

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -21,16 +21,6 @@
 //!             // These resources are available to systems, and from the Context at run-time.
 //!             resources.add_resource(SomeResource);
 //!         })
-//!         .with_update_schedule(|schedule| {
-//!             // Here is where you build up the Update schedule.
-//!             // This schedule is ran when you call Context::update().
-//!             schedule.add_system(example_system());
-//!         })
-//!         .with_render_schedule(|schedule| {
-//!             // Here is where you build up the Render schedule.
-//!             // This schedule is ran when you call Context::render().
-//!             schedule.add_system(example_system());
-//!         })
 //!         .build();
 //!     
 //!     // The Event-Loop will continue to return events, every call, until a Quit event is sent,
@@ -85,9 +75,7 @@ pub mod ecs {
         ///
         /// If the provided type has previously been added, the existing instance is silently
         /// overwritten.
-        ///
-        /// This function is functionally-identical to calling [`Resources::insert()`].
-        pub fn add_resource<T: systems::Resource + 'static>(&mut self, resource: T) -> &mut Self {
+        /// This function is functionally-identical to calling [`Resources::insert()`]. pub fn add_resource<T: systems::Resource + 'static>(&mut self, resource: T) -> &mut Self {
             self.resources.insert(resource);
             self
         }
@@ -177,20 +165,6 @@ mod init_tests {
         let (_event_loop, _context) = crate::init::<()>()
             .with_resources(|resources| {
                 resources.add_resource(0).add_resource(true);
-            })
-            .with_update_schedule(|schedule| {
-                schedule
-                    .add_system(test_system())
-                    .add_thread_local(test_system())
-                    .flush()
-                    .add_thread_local_fn(|_, _| {});
-            })
-            .with_render_schedule(|schedule| {
-                schedule
-                    .add_system(test_system())
-                    .add_thread_local(test_system())
-                    .flush()
-                    .add_thread_local_fn(|_, _| {});
             })
             .build();
     }

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -108,8 +108,6 @@ pub type Engine<E> = (EventLoop<E>, Context<E>);
 /// Provides a common interface for configuring the [`Engine`].
 pub struct EngineBuilder<E: UserEvent> {
     resources: ResourcesBuilder,
-    update_schedule_builder: ScheduleBuidler,
-    render_schedule_builder: ScheduleBuidler,
     _event_type: PhantomData<E>,
 }
 
@@ -117,8 +115,6 @@ impl<E: UserEvent> EngineBuilder<E> {
     pub(crate) fn new() -> Self {
         Self {
             resources: ResourcesBuilder::default(),
-            update_schedule_builder: Schedule::builder(),
-            render_schedule_builder: Schedule::builder(),
             _event_type: PhantomData,
         }
     }
@@ -126,18 +122,6 @@ impl<E: UserEvent> EngineBuilder<E> {
     /// Add resources to the [`Engine`].
     pub fn with_resources(mut self, function: fn(&mut ResourcesBuilder)) -> Self {
         (function)(&mut self.resources);
-        self
-    }
-
-    /// Add systems to be run while updating.
-    pub fn with_update_schedule(mut self, function: fn(&mut ScheduleBuidler)) -> Self {
-        (function)(&mut self.update_schedule_builder);
-        self
-    }
-
-    /// Add systems to be run while rendering.
-    pub fn with_render_schedule(mut self, function: fn(&mut ScheduleBuidler)) -> Self {
-        (function)(&mut self.render_schedule_builder);
         self
     }
 

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -22,20 +22,29 @@
 //!             resources.add_resource(SomeResource);
 //!         })
 //!         .build();
+//!
+//!     let mut schedule = Schedule::builder()
+//!         .add_system(example_system())
+//!         .build()
 //!     
 //!     // The Event-Loop will continue to return events, every call, until a Quit event is sent,
 //!     // only then, will the Event-Loop will return None.
 //!     while let Some(event) = event_loop.next_event() {
-//!         process_event(event, &mut context);
+//!         process_event(event, &mut context, &mut schedule);
 //!     }
 //! }
 //!
-//! pub fn process_event(event: Event<()>, context: &mut Context<()>) {
+//! pub fn process_event(event: Event<()>, context: &mut Context<()>, schedule: &mut Schedule) {
 //!     match event {
 //!         // Indicates there are no more events on the queue, or, essentially, the end of the
 //!         // current frame.  
 //!         Event::EventsCleared => {
 //!             // You should put most of your game logic here.
+//!
+//!             // You can run ECS schedules through the Context.
+//!             context.run_schedule(schedule);
+//!
+//!             // To close the game.
 //! #           context.quit();
 //!         }
 //!         // Shut down the game.

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -76,6 +76,7 @@ pub mod ecs {
         /// If the provided type has previously been added, the existing instance is silently
         /// overwritten.
         /// This function is functionally-identical to calling [`Resources::insert()`]. pub fn add_resource<T: systems::Resource + 'static>(&mut self, resource: T) -> &mut Self {
+        pub fn add_resource<T: systems::Resource + 'static>(&mut self, resource: T) -> &mut Self {
             self.resources.insert(resource);
             self
         }

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -46,8 +46,6 @@
 //!         // current frame.  
 //!         Event::EventsCleared => {
 //!             // You should put most of your game logic here.
-//!             context.update();
-//!             context.render();
 //! #           context.quit();
 //!         }
 //!         // Shut down the game.

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //!     let mut schedule = Schedule::builder()
 //!         .add_system(example_system())
-//!         .build()
+//!         .build();
 //!     
 //!     // The Event-Loop will continue to return events, every call, until a Quit event is sent,
 //!     // only then, will the Event-Loop will return None.
@@ -69,6 +69,12 @@ pub use event_loop::*;
 pub mod ecs {
     pub use legion::*;
     pub use wolf_engine_codegen::system;
+    
+    #[doc(hidden)]
+    pub mod prelude {
+        pub use super::Schedule;
+        pub use super::system;
+    }
 
     /// A, more clearly-named, alias to [`systems::Builder`].
     pub type ScheduleBuidler = legion::systems::Builder;
@@ -105,6 +111,7 @@ pub mod logging;
 pub mod prelude {
     pub use super::*;
     pub use events::*;
+    pub use ecs::prelude::*;
 }
 
 use ecs::*;

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -160,8 +160,6 @@ impl<E: UserEvent> EngineBuilder<E> {
         self.resources.add_resource(event_loop.event_sender());
         let context = Context::<E>::builder()
             .with_resources(self.resources.build())
-            .with_update_schedule(self.update_schedule_builder.build())
-            .with_render_schedule(self.render_schedule_builder.build())
             .build(&event_loop);
         (event_loop, context)
     }

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -69,11 +69,11 @@ pub use event_loop::*;
 pub mod ecs {
     pub use legion::*;
     pub use wolf_engine_codegen::system;
-    
+
     #[doc(hidden)]
     pub mod prelude {
-        pub use super::Schedule;
         pub use super::system;
+        pub use super::Schedule;
     }
 
     /// Provides a builder-pattern for creating [`Resources`].
@@ -107,8 +107,8 @@ pub mod logging;
 #[doc(hidden)]
 pub mod prelude {
     pub use super::*;
-    pub use events::*;
     pub use ecs::prelude::*;
+    pub use events::*;
 }
 
 use ecs::*;


### PR DESCRIPTION
This PR removes the `update_schedule`, and `render_schedule`, as well as all supporting functions, and replaces it with a single `run_schedule` method.  This change has been made because I'm planning to move schedules to a scene system, rather than having just 1 set of schedules for the whole engine.

The `Context` still handles the `world`, and `resources`, the user (or the framework) is expected to manage schedules on their own.

# Changes Made

All notable changes introduced by this PR should be documented here.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

- Removed `update_schedule` field from `Context`.
- Removed `render_schedule` field from `Context`.
- Removed `update_schedule()` accessor from `Context`.
- Removed `update_schedule_mut()` accessor field from `Context`.
- Removed `render_schedule()` accessor from `Context`.
- Removed `render_schedule_mut()` accessor field from `Context`.
- Removed `with_update_schedule()` method from `EngineBuilder`.
- Removed `with_render_schedule()` method from `EngineBuilder`.
- Removed `ScheduleBuilder` typedef.
- Added `run_schedule()` method to `Context.
- Added `ecs::prelude` module.
- Added `ecs::Schedule` to the prelude.
- Added `ecs::system` to the prelude.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR
can be accepted.

- [x] New behaviors are covered by tests, and / or examples.
- [x] The documentation has been updated (if applicable.)
- [x] The version number has been bumped (if applicable.)
- [x] The feature branch is up to date with `main`. 
