### PR TITLE
Feature: Plugin System

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,7 @@ required-features = ["logging"]
 [[example]]
 name = "logging"
 required-features = ["logging"]
+
+[[example]]
+name = "plugins"
+required-features = ["framework"]

--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -21,11 +21,12 @@ fn quit_after_3_updates(
 
 pub fn main() {
     logging::initialize_logging(logging::LogLevel::Info);
+    
+    let mut resources = ResourcesBuilder::default();
+    resources.add_resource(Message("Hello, World!"));
 
     let (mut event_loop, mut context) = wolf_engine::init()
-        .with_resources(|resources| {
-            resources.add_resource(Message("Hello, World!"));
-        })
+        .with_resources(resources)
         .build();
 
     let mut schedule = Schedule::builder()

--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -21,13 +21,11 @@ fn quit_after_3_updates(
 
 pub fn main() {
     logging::initialize_logging(logging::LogLevel::Info);
-    
+
     let mut resources = ResourcesBuilder::default();
     resources.add_resource(Message("Hello, World!"));
 
-    let (mut event_loop, mut context) = wolf_engine::init()
-        .with_resources(resources)
-        .build();
+    let (mut event_loop, mut context) = wolf_engine::init().with_resources(resources).build();
 
     let mut schedule = Schedule::builder()
         .add_system(log_message_system())

--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -22,10 +22,9 @@ fn quit_after_3_updates(
 pub fn main() {
     logging::initialize_logging(logging::LogLevel::Info);
 
-    let mut resources = ResourcesBuilder::default();
-    resources.add_resource(Message("Hello, World!"));
-
-    let (mut event_loop, mut context) = wolf_engine::init().with_resources(resources).build();
+    let (mut event_loop, mut context) = wolf_engine::framework::init()
+        .with_resource(Message("Hello, World!"))
+        .build();
 
     let mut schedule = Schedule::builder()
         .add_system(log_message_system())

--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -7,7 +7,9 @@ pub fn main() {
 
     let (mut event_loop, mut context) = wolf_engine::framework::init()
         .with_resource(Message("Hello, World!"))
-        .build();
+        .build()
+        .unwrap();
+        
 
     let mut schedule = Schedule::builder()
         .add_system(log_message_system())

--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -9,7 +9,6 @@ pub fn main() {
         .with_resource(Message("Hello, World!"))
         .build()
         .unwrap();
-        
 
     let mut schedule = Schedule::builder()
         .add_system(log_message_system())
@@ -47,4 +46,3 @@ fn quit_after_3_updates(
         *updates += 1;
     }
 }
-

--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -30,8 +30,8 @@ pub fn main() {
         .build();
 
     let mut schedule = Schedule::builder()
-        .add_thread_local(log_message_system())
-        .add_thread_local(quit_after_3_updates_system(1))
+        .add_system(log_message_system())
+        .add_system(quit_after_3_updates_system(1))
         .build();
 
     while let Some(event) = event_loop.next_event() {

--- a/examples/minimal_hello_world.rs
+++ b/examples/minimal_hello_world.rs
@@ -2,23 +2,6 @@ use wolf_engine::prelude::*;
 
 pub struct Message(&'static str);
 
-#[wolf_engine::ecs::system]
-fn log_message(#[resource] message: &Message) {
-    log::info!("{}", message.0);
-}
-
-#[wolf_engine::ecs::system]
-fn quit_after_3_updates(
-    #[state] updates: &mut u32,
-    #[resource] event_sender: &MainEventSender<()>,
-) {
-    if *updates == 3 {
-        event_sender.send_event(Event::Quit).ok();
-    } else {
-        *updates += 1;
-    }
-}
-
 pub fn main() {
     logging::initialize_logging(logging::LogLevel::Info);
 
@@ -45,3 +28,21 @@ pub fn process_event(event: Event<()>, context: &mut Context<()>, schedule: &mut
         _ => (),
     }
 }
+
+#[wolf_engine::ecs::system]
+fn log_message(#[resource] message: &Message) {
+    log::info!("{}", message.0);
+}
+
+#[wolf_engine::ecs::system]
+fn quit_after_3_updates(
+    #[state] updates: &mut u32,
+    #[resource] event_sender: &MainEventSender<()>,
+) {
+    if *updates == 3 {
+        event_sender.send_event(Event::Quit).ok();
+    } else {
+        *updates += 1;
+    }
+}
+

--- a/examples/plugins.rs
+++ b/examples/plugins.rs
@@ -1,8 +1,8 @@
 use std::marker::PhantomData;
 
-use wolf_engine::prelude::*;
-use wolf_engine::framework::FrameworkBuilder;
 use wolf_engine::framework::plugins::*;
+use wolf_engine::framework::FrameworkBuilder;
+use wolf_engine::prelude::*;
 
 // Just a test resource used by our plugin.
 pub struct MyResource(String);
@@ -40,11 +40,9 @@ pub fn main() {
         .with_plugin(MyPlugin::new()) // Plugins are added at startup.
         .build()
         .unwrap();
-    
+
     // Resources added by plugins can be accessed just like any other resource.
-    let plugin_resource = context.resources()
-        .get::<MyResource>()
-        .unwrap();
+    let plugin_resource = context.resources().get::<MyResource>().unwrap();
 
     println!("{}", plugin_resource.0);
 }

--- a/examples/plugins.rs
+++ b/examples/plugins.rs
@@ -1,0 +1,50 @@
+use std::marker::PhantomData;
+
+use wolf_engine::prelude::*;
+use wolf_engine::framework::FrameworkBuilder;
+use wolf_engine::framework::plugins::*;
+
+// Just a test resource used by our plugin.
+pub struct MyResource(String);
+
+pub struct MyPlugin<E: UserEvent> {
+    // Because plugins have a generic type, we need to include `PhantomData`, or the compiler will
+    // complain.
+    _event_type: PhantomData<E>,
+}
+
+impl<E: UserEvent> MyPlugin<E> {
+    pub fn new() -> Self {
+        Self {
+            _event_type: PhantomData,
+        }
+    }
+}
+
+impl<E: UserEvent> Plugin<E> for MyPlugin<E> {
+    fn name(&self) -> &str {
+        // Return a name to identify the plugin in logs.
+        "Test Plugin"
+    }
+
+    fn load(&mut self, builder: &mut FrameworkBuilder<E>) -> PluginResult {
+        // Plugins can add resources to the engine.
+        builder.with_resource(MyResource("Hello, world!".to_string()));
+
+        Ok(())
+    }
+}
+
+pub fn main() {
+    let (_event_loop, context) = wolf_engine::framework::init::<()>()
+        .with_plugin(MyPlugin::new()) // Plugins are added at startup.
+        .build()
+        .unwrap();
+    
+    // Resources added by plugins can be accessed just like any other resource.
+    let plugin_resource = context.resources()
+        .get::<MyResource>()
+        .unwrap();
+
+    println!("{}", plugin_resource.0);
+}

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -18,11 +18,6 @@ pub struct Context<E: UserEvent> {
 }
 
 impl<E: UserEvent> Context<E> {
-    /// Create a new `Context` from the provided [`EventQueue`] and data.
-    pub(crate) fn builder() -> ContextBuilder {
-        ContextBuilder::new()
-    }
-
     pub fn run_schedule(&mut self, schedule: &mut Schedule) {
         schedule.execute(&mut self.world, &mut self.resources);
     }
@@ -56,33 +51,6 @@ impl<E: UserEvent> Context<E> {
 impl<E: UserEvent> HasEventSender<Event<E>> for Context<E> {
     fn event_sender(&self) -> Arc<dyn EventSender<Event<E>>> {
         self.event_sender.clone()
-    }
-}
-
-pub(crate) struct ContextBuilder {
-    world: World,
-    resources: Resources,
-}
-
-impl ContextBuilder {
-    pub(crate) fn new() -> Self {
-        Self {
-            world: Default::default(),
-            resources: Default::default(),
-        }
-    }
-
-    pub fn with_resources(mut self, resources: Resources) -> Self {
-        self.resources = resources;
-        self
-    }
-
-    pub fn build<E: UserEvent>(self, event_loop: &EventLoop<E>) -> Context<E> {
-        Context {
-            world: self.world,
-            resources: self.resources,
-            event_sender: event_loop.event_sender(),
-        }
     }
 }
 

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -90,16 +90,18 @@ impl ContextBuilder {
 mod context_tests {
     use legion::Schedule;
 
+    use crate::ecs::ResourcesBuilder;
+
     #[test]
     fn should_run_ecs_tick() {
         #[legion::system]
         fn add_1(#[resource] number: &mut i32) {
             *number += 1;
         }
+        let mut resources = ResourcesBuilder::default();
+        resources.add_resource(0);
         let (_, mut context) = crate::init::<()>()
-            .with_resources(|resources| {
-                resources.add_resource(0);
-            })
+            .with_resources(resources)
             .build();
 
         let mut schedule = Schedule::builder().add_system(add_1_system()).build();

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -55,9 +55,7 @@ impl<E: UserEvent> HasEventSender<Event<E>> for Context<E> {
 
 #[cfg(test)]
 mod context_tests {
-    use legion::Schedule;
-
-    use crate::ecs::Resources;
+    use crate::ecs::{Resources, Schedule};
 
     #[test]
     fn should_run_ecs_tick() {

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -67,9 +67,7 @@ mod context_tests {
         }
         let mut resources = ResourcesBuilder::default();
         resources.add_resource(0);
-        let (_, mut context) = crate::init::<()>()
-            .with_resources(resources)
-            .build();
+        let (_, mut context) = crate::init::<()>().with_resources(resources).build();
 
         let mut schedule = Schedule::builder().add_system(add_1_system()).build();
 

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -9,7 +9,7 @@ use crate::events::*;
 /// [`EventLoop`](crate::EventLoop`).  Together, these two parts make up what we refer to as
 /// ["the engine"](crate::Engine).
 ///
-/// The Context owns all engine data, including resources, system schedules, and the game world.
+/// The Context owns all engine data, including resources, and the game world.
 pub struct Context<E: UserEvent> {
     pub(crate) world: World,
     pub(crate) resources: Resources,

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use crate::ecs::*;
 use crate::events::*;
-use crate::EventLoop;
 
 /// Provides a container for Wolf Engine's user-facing data.
 ///

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -57,7 +57,7 @@ impl<E: UserEvent> HasEventSender<Event<E>> for Context<E> {
 mod context_tests {
     use legion::Schedule;
 
-    use crate::ecs::ResourcesBuilder;
+    use crate::ecs::Resources;
 
     #[test]
     fn should_run_ecs_tick() {
@@ -65,8 +65,8 @@ mod context_tests {
         fn add_1(#[resource] number: &mut i32) {
             *number += 1;
         }
-        let mut resources = ResourcesBuilder::default();
-        resources.add_resource(0);
+        let mut resources = Resources::default();
+        resources.insert(0);
         let (_, mut context) = crate::init::<()>().with_resources(resources).build();
 
         let mut schedule = Schedule::builder().add_system(add_1_system()).build();

--- a/wolf_engine_core/src/context.rs
+++ b/wolf_engine_core/src/context.rs
@@ -12,9 +12,9 @@ use crate::EventLoop;
 ///
 /// The Context owns all engine data, including resources, system schedules, and the game world.
 pub struct Context<E: UserEvent> {
-    world: World,
-    resources: Resources,
-    event_sender: Arc<dyn EventSender<Event<E>>>,
+    pub(crate) world: World,
+    pub(crate) resources: Resources,
+    pub(crate) event_sender: Arc<dyn EventSender<Event<E>>>,
 }
 
 impl<E: UserEvent> Context<E> {

--- a/wolf_engine_core/src/ecs.rs
+++ b/wolf_engine_core/src/ecs.rs
@@ -6,29 +6,6 @@ pub use wolf_engine_codegen::system;
 #[doc(hidden)]
 pub mod prelude {
     pub use super::system;
-    pub use super::ResourcesBuilder;
     pub use super::Schedule;
 }
 
-/// Provides a builder-pattern for creating [`Resources`].
-#[derive(Default)]
-pub struct ResourcesBuilder {
-    resources: Resources,
-}
-
-impl ResourcesBuilder {
-    /// Inserts the provide instance of `T` into the [`Resources`].
-    ///
-    /// If the provided type has previously been added, the existing instance is silently
-    /// overwritten.
-    /// This function is functionally-identical to calling [`Resources::insert()`]. pub fn add_resource<T: systems::Resource + 'static>(&mut self, resource: T) -> &mut Self {
-    pub fn add_resource<T: systems::Resource + 'static>(&mut self, resource: T) -> &mut Self {
-        self.resources.insert(resource);
-        self
-    }
-
-    /// Consumes the builder, and returns the [`Resources`] from it.
-    pub fn build(self) -> Resources {
-        self.resources
-    }
-}

--- a/wolf_engine_core/src/ecs.rs
+++ b/wolf_engine_core/src/ecs.rs
@@ -1,0 +1,34 @@
+//! Provides an Entity-Component-System based on [Legion](::legion).
+
+pub use legion::*;
+pub use wolf_engine_codegen::system;
+
+#[doc(hidden)]
+pub mod prelude {
+    pub use super::system;
+    pub use super::ResourcesBuilder;
+    pub use super::Schedule;
+}
+
+/// Provides a builder-pattern for creating [`Resources`].
+#[derive(Default)]
+pub struct ResourcesBuilder {
+    resources: Resources,
+}
+
+impl ResourcesBuilder {
+    /// Inserts the provide instance of `T` into the [`Resources`].
+    ///
+    /// If the provided type has previously been added, the existing instance is silently
+    /// overwritten.
+    /// This function is functionally-identical to calling [`Resources::insert()`]. pub fn add_resource<T: systems::Resource + 'static>(&mut self, resource: T) -> &mut Self {
+    pub fn add_resource<T: systems::Resource + 'static>(&mut self, resource: T) -> &mut Self {
+        self.resources.insert(resource);
+        self
+    }
+
+    /// Consumes the builder, and returns the [`Resources`] from it.
+    pub fn build(self) -> Resources {
+        self.resources
+    }
+}

--- a/wolf_engine_core/src/ecs.rs
+++ b/wolf_engine_core/src/ecs.rs
@@ -8,4 +8,3 @@ pub mod prelude {
     pub use super::system;
     pub use super::Schedule;
 }
-

--- a/wolf_engine_core/src/engine_builder.rs
+++ b/wolf_engine_core/src/engine_builder.rs
@@ -1,8 +1,7 @@
 use std::marker::PhantomData;
 
+use crate::ecs::{ResourcesBuilder, World};
 use crate::prelude::*;
-use crate::ecs::{World, ResourcesBuilder};
-
 
 /// Represents the [`EventLoop`]-[`Context`] pair that makes up "the engine."
 pub type Engine<E> = (EventLoop<E>, Context<E>);

--- a/wolf_engine_core/src/engine_builder.rs
+++ b/wolf_engine_core/src/engine_builder.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use crate::ecs::World;
 use crate::prelude::*;
 
 /// Represents the [`EventLoop`]-[`Context`] pair that makes up "the engine."

--- a/wolf_engine_core/src/engine_builder.rs
+++ b/wolf_engine_core/src/engine_builder.rs
@@ -32,7 +32,7 @@ impl<E: UserEvent> EngineBuilder<E> {
         self.resources.insert(event_loop.event_sender());
         let context = Context {
             world: World::default(),
-            resources: self.resources, 
+            resources: self.resources,
             event_sender: event_loop.event_sender(),
         };
         (event_loop, context)

--- a/wolf_engine_core/src/engine_builder.rs
+++ b/wolf_engine_core/src/engine_builder.rs
@@ -1,7 +1,8 @@
 use std::marker::PhantomData;
 
-use crate::ecs::World;
 use crate::prelude::*;
+use crate::ecs::{World, ResourcesBuilder};
+
 
 /// Represents the [`EventLoop`]-[`Context`] pair that makes up "the engine."
 pub type Engine<E> = (EventLoop<E>, Context<E>);

--- a/wolf_engine_core/src/engine_builder.rs
+++ b/wolf_engine_core/src/engine_builder.rs
@@ -1,0 +1,39 @@
+use std::marker::PhantomData;
+
+use crate::prelude::*;
+
+/// Represents the [`EventLoop`]-[`Context`] pair that makes up "the engine."
+pub type Engine<E> = (EventLoop<E>, Context<E>);
+
+/// Provides a common interface for configuring the [`Engine`].
+pub struct EngineBuilder<E: UserEvent> {
+    resources: ResourcesBuilder,
+    _event_type: PhantomData<E>,
+}
+
+impl<E: UserEvent> EngineBuilder<E> {
+    pub(crate) fn new() -> Self {
+        Self {
+            resources: ResourcesBuilder::default(),
+            _event_type: PhantomData,
+        }
+    }
+
+    /// Add resources to the [`Engine`].
+    pub fn with_resources(mut self, resources: ResourcesBuilder) -> Self {
+        self.resources = resources;
+        self
+    }
+
+    /// Consume the builder, and return the [`Engine`] created from it.
+    pub fn build(mut self) -> Engine<E> {
+        let event_loop = EventLoop::new();
+        self.resources.add_resource(event_loop.event_sender());
+        let context = Context {
+            world: World::default(),
+            resources: self.resources.build(),
+            event_sender: event_loop.event_sender(),
+        };
+        (event_loop, context)
+    }
+}

--- a/wolf_engine_core/src/engine_builder.rs
+++ b/wolf_engine_core/src/engine_builder.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::ecs::{ResourcesBuilder, World};
+use crate::ecs::{Resources, World};
 use crate::prelude::*;
 
 /// Represents the [`EventLoop`]-[`Context`] pair that makes up "the engine."
@@ -8,20 +8,20 @@ pub type Engine<E> = (EventLoop<E>, Context<E>);
 
 /// Provides a common interface for configuring the [`Engine`].
 pub struct EngineBuilder<E: UserEvent> {
-    resources: ResourcesBuilder,
+    resources: Resources,
     _event_type: PhantomData<E>,
 }
 
 impl<E: UserEvent> EngineBuilder<E> {
     pub(crate) fn new() -> Self {
         Self {
-            resources: ResourcesBuilder::default(),
+            resources: Resources::default(),
             _event_type: PhantomData,
         }
     }
 
     /// Add resources to the [`Engine`].
-    pub fn with_resources(mut self, resources: ResourcesBuilder) -> Self {
+    pub fn with_resources(mut self, resources: Resources) -> Self {
         self.resources = resources;
         self
     }
@@ -29,10 +29,10 @@ impl<E: UserEvent> EngineBuilder<E> {
     /// Consume the builder, and return the [`Engine`] created from it.
     pub fn build(mut self) -> Engine<E> {
         let event_loop = EventLoop::new();
-        self.resources.add_resource(event_loop.event_sender());
+        self.resources.insert(event_loop.event_sender());
         let context = Context {
             world: World::default(),
-            resources: self.resources.build(),
+            resources: self.resources, 
             event_sender: event_loop.event_sender(),
         };
         (event_loop, context)

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -169,7 +169,9 @@ mod init_tests {
         let mut resources = ResourcesBuilder::default();
         resources.add_resource(0).add_resource(true);
 
-        let (_event_loop, _context) = crate::init::<()>().with_resources(resources).build();
+        let (_event_loop, context) = crate::init::<()>().with_resources(resources).build();
+
+        assert!(context.resources().get::<i32>().is_some(), "The resources were not used");
     }
 
     #[test]

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -66,6 +66,8 @@ mod context;
 pub use context::*;
 mod event_loop;
 pub use event_loop::*;
+mod engine_builder;
+pub use engine_builder::*;
 
 pub mod ecs;
 pub mod events;

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -67,7 +67,6 @@ mod event_loop;
 pub use event_loop::*;
 mod engine_builder;
 pub use engine_builder::*;
-use prelude::UserEvent;
 
 pub mod ecs;
 pub mod events;
@@ -81,6 +80,8 @@ pub mod prelude {
     pub use ecs::prelude::*;
     pub use events::*;
 }
+
+use crate::prelude::UserEvent;
 
 /// Creates a new [`EngineBuilder`] to set up the [`Engine`].
 pub fn init<E: UserEvent>() -> EngineBuilder<E> {

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -165,7 +165,7 @@ mod init_tests {
     use crate::{ecs::ResourcesBuilder, events::MainEventSender};
 
     #[test]
-    fn should_use_builder_pattern() {
+    fn should_add_resources() {
         let mut resources = ResourcesBuilder::default();
         resources.add_resource(0).add_resource(true);
 

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -68,41 +68,7 @@ pub use context::*;
 mod event_loop;
 pub use event_loop::*;
 
-/// Provides an Entity-Component-System based on [Legion](::legion).
-pub mod ecs {
-    pub use legion::*;
-    pub use wolf_engine_codegen::system;
-
-    #[doc(hidden)]
-    pub mod prelude {
-        pub use super::system;
-        pub use super::ResourcesBuilder;
-        pub use super::Schedule;
-    }
-
-    /// Provides a builder-pattern for creating [`Resources`].
-    #[derive(Default)]
-    pub struct ResourcesBuilder {
-        resources: Resources,
-    }
-
-    impl ResourcesBuilder {
-        /// Inserts the provide instance of `T` into the [`Resources`].
-        ///
-        /// If the provided type has previously been added, the existing instance is silently
-        /// overwritten.
-        /// This function is functionally-identical to calling [`Resources::insert()`]. pub fn add_resource<T: systems::Resource + 'static>(&mut self, resource: T) -> &mut Self {
-        pub fn add_resource<T: systems::Resource + 'static>(&mut self, resource: T) -> &mut Self {
-            self.resources.insert(resource);
-            self
-        }
-
-        /// Consumes the builder, and returns the [`Resources`] from it.
-        pub fn build(self) -> Resources {
-            self.resources
-        }
-    }
-}
+pub mod ecs;
 pub mod events;
 
 #[cfg(feature = "logging")]

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -14,13 +14,16 @@
 //! # fn example() {}
 //!
 //! pub fn main() {
-//!     // Start by initializing the engine's Event-Loop, and Context.
+//!     // Start by setting up Resources, or custom data for the engine.
+//!     // These resources are available to systems, and from the Context at run-time.
+//!     // This step is optional.
+//!     let mut resources = ResourcesBuilder::default();
+//!     resources.add_resource(SomeResource);
+//!
+//!     // Then initalize the EventLoop, and Context.
+//!     // Resources, and other settings can also be set up from here.
 //!     let (mut event_loop, mut context) = wolf_engine::init::<()>()
-//!         .with_resources(|resources| {
-//!             // Here is where you add Resources, or custom data to the engine.
-//!             // These resources are available to systems, and from the Context at run-time.
-//!             resources.add_resource(SomeResource);
-//!         })
+//!         .with_resources(resources)
 //!         .build();
 //!
 //!     let mut schedule = Schedule::builder()

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -76,8 +76,8 @@ pub mod ecs {
     #[doc(hidden)]
     pub mod prelude {
         pub use super::system;
-        pub use super::Schedule;
         pub use super::ResourcesBuilder;
+        pub use super::Schedule;
     }
 
     /// Provides a builder-pattern for creating [`Resources`].
@@ -162,16 +162,14 @@ pub fn init<E: UserEvent>() -> EngineBuilder<E> {
 
 #[cfg(test)]
 mod init_tests {
-    use crate::{events::MainEventSender, ecs::ResourcesBuilder};
+    use crate::{ecs::ResourcesBuilder, events::MainEventSender};
 
     #[test]
     fn should_use_builder_pattern() {
         let mut resources = ResourcesBuilder::default();
         resources.add_resource(0).add_resource(true);
 
-        let (_event_loop, _context) = crate::init::<()>()
-            .with_resources(resources)
-            .build();
+        let (_event_loop, _context) = crate::init::<()>().with_resources(resources).build();
     }
 
     #[test]

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -61,9 +61,8 @@
 //! [examples folder](https://github.com/AlexiWolf/wolf_engine/tree/main/examples) for additional
 //! examples.
 
-mod context;
-use std::marker::PhantomData;
 
+mod context;
 pub use context::*;
 mod event_loop;
 pub use event_loop::*;
@@ -81,9 +80,10 @@ pub mod prelude {
     pub use events::*;
 }
 
-use ecs::*;
-use events::UserEvent;
-use prelude::events::HasEventSender;
+use std::marker::PhantomData;
+
+use ecs::{ResourcesBuilder, World};
+use events::{UserEvent, HasEventSender};
 
 /// Represents the [`EventLoop`]-[`Context`] pair that makes up "the engine."
 pub type Engine<E> = (EventLoop<E>, Context<E>);

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -74,6 +74,7 @@ pub mod ecs {
     pub mod prelude {
         pub use super::system;
         pub use super::Schedule;
+        pub use super::ResourcesBuilder;
     }
 
     /// Provides a builder-pattern for creating [`Resources`].
@@ -133,8 +134,8 @@ impl<E: UserEvent> EngineBuilder<E> {
     }
 
     /// Add resources to the [`Engine`].
-    pub fn with_resources(mut self, function: fn(&mut ResourcesBuilder)) -> Self {
-        (function)(&mut self.resources);
+    pub fn with_resources(mut self, resources: ResourcesBuilder) -> Self {
+        self.resources = resources;
         self
     }
 
@@ -156,14 +157,15 @@ pub fn init<E: UserEvent>() -> EngineBuilder<E> {
 
 #[cfg(test)]
 mod init_tests {
-    use crate::events::MainEventSender;
+    use crate::{events::MainEventSender, ecs::ResourcesBuilder};
 
     #[test]
     fn should_use_builder_pattern() {
+        let mut resources = ResourcesBuilder::default();
+        resources.add_resource(0).add_resource(true);
+
         let (_event_loop, _context) = crate::init::<()>()
-            .with_resources(|resources| {
-                resources.add_resource(0).add_resource(true);
-            })
+            .with_resources(resources)
             .build();
     }
 

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -182,9 +182,4 @@ mod init_tests {
             .get_mut::<MainEventSender<()>>()
             .expect("No event sender was added.");
     }
-
-    #[legion::system]
-    fn test() {
-        println!("Hello, world!");
-    }
 }

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -146,9 +146,11 @@ impl<E: UserEvent> EngineBuilder<E> {
     pub fn build(mut self) -> Engine<E> {
         let event_loop = EventLoop::new();
         self.resources.add_resource(event_loop.event_sender());
-        let context = Context::<E>::builder()
-            .with_resources(self.resources.build())
-            .build(&event_loop);
+        let context = Context {
+            world: World::default(),
+            resources: self.resources.build(),
+            event_sender: event_loop.event_sender(),
+        };
         (event_loop, context)
     }
 }

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -175,7 +175,7 @@ mod init_tests {
     }
 
     #[test]
-    fn should_add_event_sender_resource() {
+    fn should_add_event_sender_resource_by_default() {
         let (_event_loop, context) = crate::init::<()>().build();
         let _event_sender = context
             .resources()

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -83,14 +83,14 @@ pub mod prelude {
 
 use crate::prelude::UserEvent;
 
-/// Initializes Wolf Engine using the [`EngineBuilder`]. 
+/// Initializes Wolf Engine using the [`EngineBuilder`].
 pub fn init<E: UserEvent>() -> EngineBuilder<E> {
     EngineBuilder::new()
 }
 
 #[cfg(test)]
 mod init_tests {
-    use crate::ecs::Resources; 
+    use crate::ecs::Resources;
     use crate::events::MainEventSender;
 
     #[test]

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```
 //! # use wolf_engine_core as wolf_engine;
 //! # use wolf_engine::prelude::*;
-//! # use wolf_engine::ecs::{Schedule, ResourcesBuilder};
+//! # use wolf_engine::ecs::{Schedule, Resources};
 //! #
 //! # struct SomeResource;
 //! #
@@ -18,8 +18,8 @@
 //!     // Start by setting up Resources, or custom data for the engine.
 //!     // These resources are available to systems, and from the Context at run-time.
 //!     // This step is optional.
-//!     let mut resources = ResourcesBuilder::default();
-//!     resources.add_resource(SomeResource);
+//!     let mut resources = Resources::default();
+//!     resources.insert(SomeResource);
 //!
 //!     // Then initalize the EventLoop, and Context.
 //!     // Resources, and other settings can also be set up from here.
@@ -90,12 +90,13 @@ pub fn init<E: UserEvent>() -> EngineBuilder<E> {
 
 #[cfg(test)]
 mod init_tests {
-    use crate::{ecs::ResourcesBuilder, events::MainEventSender};
+    use crate::ecs::Resources; 
+    use crate::events::MainEventSender;
 
     #[test]
     fn should_add_resources() {
-        let mut resources = ResourcesBuilder::default();
-        resources.add_resource(0).add_resource(true);
+        let mut resources = Resources::default();
+        resources.insert(0);
 
         let (_event_loop, context) = crate::init::<()>().with_resources(resources).build();
 

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -83,7 +83,7 @@ pub mod prelude {
 
 use crate::prelude::UserEvent;
 
-/// Creates a new [`EngineBuilder`] to set up the [`Engine`].
+/// Initializes Wolf Engine using the [`EngineBuilder`]. 
 pub fn init<E: UserEvent>() -> EngineBuilder<E> {
     EngineBuilder::new()
 }

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -61,13 +61,13 @@
 //! [examples folder](https://github.com/AlexiWolf/wolf_engine/tree/main/examples) for additional
 //! examples.
 
-
 mod context;
 pub use context::*;
 mod event_loop;
 pub use event_loop::*;
 mod engine_builder;
 pub use engine_builder::*;
+use prelude::UserEvent;
 
 pub mod ecs;
 pub mod events;
@@ -80,47 +80,6 @@ pub mod prelude {
     pub use super::*;
     pub use ecs::prelude::*;
     pub use events::*;
-}
-
-use std::marker::PhantomData;
-
-use ecs::{ResourcesBuilder, World};
-use events::{UserEvent, HasEventSender};
-
-/// Represents the [`EventLoop`]-[`Context`] pair that makes up "the engine."
-pub type Engine<E> = (EventLoop<E>, Context<E>);
-
-/// Provides a common interface for configuring the [`Engine`].
-pub struct EngineBuilder<E: UserEvent> {
-    resources: ResourcesBuilder,
-    _event_type: PhantomData<E>,
-}
-
-impl<E: UserEvent> EngineBuilder<E> {
-    pub(crate) fn new() -> Self {
-        Self {
-            resources: ResourcesBuilder::default(),
-            _event_type: PhantomData,
-        }
-    }
-
-    /// Add resources to the [`Engine`].
-    pub fn with_resources(mut self, resources: ResourcesBuilder) -> Self {
-        self.resources = resources;
-        self
-    }
-
-    /// Consume the builder, and return the [`Engine`] created from it.
-    pub fn build(mut self) -> Engine<E> {
-        let event_loop = EventLoop::new();
-        self.resources.add_resource(event_loop.event_sender());
-        let context = Context {
-            world: World::default(),
-            resources: self.resources.build(),
-            event_sender: event_loop.event_sender(),
-        };
-        (event_loop, context)
-    }
 }
 
 /// Creates a new [`EngineBuilder`] to set up the [`Engine`].
@@ -139,7 +98,10 @@ mod init_tests {
 
         let (_event_loop, context) = crate::init::<()>().with_resources(resources).build();
 
-        assert!(context.resources().get::<i32>().is_some(), "The resources were not used");
+        assert!(
+            context.resources().get::<i32>().is_some(),
+            "The resources were not used"
+        );
     }
 
     #[test]

--- a/wolf_engine_core/src/lib.rs
+++ b/wolf_engine_core/src/lib.rs
@@ -6,7 +6,8 @@
 //!
 //! ```
 //! # use wolf_engine_core as wolf_engine;
-//! use wolf_engine::prelude::*;
+//! # use wolf_engine::prelude::*;
+//! # use wolf_engine::ecs::{Schedule, ResourcesBuilder};
 //! #
 //! # struct SomeResource;
 //! #
@@ -77,7 +78,6 @@ pub mod logging;
 #[doc(hidden)]
 pub mod prelude {
     pub use super::*;
-    pub use ecs::prelude::*;
     pub use events::*;
 }
 

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -21,7 +21,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
             plugin_loader: PluginLoader::new(),
         }
     }
-    
+
     /// Adds a [`Plugin`] to the engine.
     ///
     /// **Note:** Plugins are loaded when [`FrameworkBuilder::build()`] is called.
@@ -29,7 +29,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         self.plugin_loader.add_plugin(Box::from(plugin));
         self
     }
-    
+
     /// Adds a [`Resource`] of type `T` to the engine's [`Resources`].
     ///
     /// **Note:** If a provided type is already in the store, it will be silently overwritten. This
@@ -38,7 +38,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         self.resources.insert(resource);
         self
     }
-    
+
     /// Creates a new instance of [`Engine`] from the builder.
     pub fn build(&mut self) -> Result<Engine<E>, String> {
         let mut plugin_loader = std::mem::replace(&mut self.plugin_loader, PluginLoader::new());
@@ -47,8 +47,6 @@ impl<E: UserEvent> FrameworkBuilder<E> {
             Err(error) => return Err(error),
         }
         let resources = std::mem::take(&mut self.resources);
-        Ok(wolf_engine_core::init()
-            .with_resources(resources)
-            .build())
+        Ok(wolf_engine_core::init().with_resources(resources).build())
     }
 }

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -1,4 +1,4 @@
-use crate::plugins::Plugin;
+use crate::plugins::{Plugin, PluginLoder};
 
 use wolf_engine_core::ecs::systems::Resource;
 use wolf_engine_core::ecs::ResourcesBuilder;
@@ -7,19 +7,19 @@ use wolf_engine_core::Engine;
 
 pub struct FrameworkBuilder<E: UserEvent> {
     resource_builder: ResourcesBuilder,
-    plugins: Vec<Box<dyn Plugin<E>>>,
+    plugin_loader: PluginLoder<E>,
 }
 
 impl<E: UserEvent> FrameworkBuilder<E> {
     pub(crate) fn new() -> Self {
         Self {
-            plugins: Vec::new(),
             resource_builder: ResourcesBuilder::default(),
+            plugin_loader: PluginLoder::new(), 
         }
     }
 
     pub fn with_plugin<P: Plugin<E> + 'static>(mut self, plugin: P) -> Self {
-        self.plugins.push(Box::from(plugin));
+        self.plugin_loader.add_plugin(Box::from(plugin));
         self
     }
 
@@ -29,11 +29,9 @@ impl<E: UserEvent> FrameworkBuilder<E> {
     }
 
     pub fn build(mut self) -> Engine<E> {
-        let plugins = std::mem::take(&mut self.plugins);
+        let plugin_loader = std::mem::take(&mut self.plugin_loader);
 
-        for mut plugin in plugins {
-            self = plugin.load(self).expect("Failed to load plugin");
-        }
+        self = plugin_loader.load_plugins(self);
 
         wolf_engine_core::init()
             .with_resources(self.resource_builder)

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -5,6 +5,10 @@ use wolf_engine_core::ecs::Resources;
 use wolf_engine_core::events::UserEvent;
 use wolf_engine_core::Engine;
 
+/// Provides a way to configure the [`Engine`] before startup.
+///
+/// This is similar to the [`EngineBuilder`](wolf_engine_core::EngineBuilder), except it handles
+/// all of the setup for you, and provides some additional features (like a plugin system.)
 pub struct FrameworkBuilder<E: UserEvent> {
     resources: Resources,
     plugin_loader: PluginLoader<E>,
@@ -17,17 +21,25 @@ impl<E: UserEvent> FrameworkBuilder<E> {
             plugin_loader: PluginLoader::new(),
         }
     }
-
+    
+    /// Adds a [`Plugin`] to the engine.
+    ///
+    /// **Note:** Plugins are loaded when [`FrameworkBuilder::build()`] is called.
     pub fn with_plugin<P: Plugin<E> + 'static>(&mut self, plugin: P) -> &mut Self {
         self.plugin_loader.add_plugin(Box::from(plugin));
         self
     }
-
+    
+    /// Adds a [`Resource`] of type `T` to the engine's [`Resources`].
+    ///
+    /// **Note:** If a provided type is already in the store, it will be silently overwritten. This
+    /// behavior is consistent with [`Resources::insert()`].
     pub fn with_resource<T: Resource>(&mut self, resource: T) -> &mut Self {
         self.resources.insert(resource);
         self
     }
-
+    
+    /// Creates a new instance of [`Engine`] from the builder.
     pub fn build(&mut self) -> Result<Engine<E>, String> {
         let mut plugin_loader = std::mem::replace(&mut self.plugin_loader, PluginLoader::new());
         match plugin_loader.load_plugins(self) {

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -1,19 +1,19 @@
 use crate::plugins::{Plugin, PluginLoder};
 
 use wolf_engine_core::ecs::systems::Resource;
-use wolf_engine_core::ecs::ResourcesBuilder;
+use wolf_engine_core::ecs::Resources;
 use wolf_engine_core::events::UserEvent;
 use wolf_engine_core::Engine;
 
 pub struct FrameworkBuilder<E: UserEvent> {
-    resource_builder: ResourcesBuilder,
+    resources: Resources,
     plugin_loader: PluginLoder<E>,
 }
 
 impl<E: UserEvent> FrameworkBuilder<E> {
     pub(crate) fn new() -> Self {
         Self {
-            resource_builder: ResourcesBuilder::default(),
+            resources: Resources::default(),
             plugin_loader: PluginLoder::new(),
         }
     }
@@ -24,7 +24,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
     }
 
     pub fn with_resource<T: Resource + 'static>(&mut self, resource: T) -> &mut Self {
-        self.resource_builder.add_resource(resource);
+        self.resources.insert(resource);
         self
     }
 
@@ -34,7 +34,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
             Ok(_) => (),
             Err(error) => return Err(error),
         }
-        let resource_builder = std::mem::take(&mut self.resource_builder);
+        let resource_builder = std::mem::take(&mut self.resources);
         Ok(wolf_engine_core::init()
             .with_resources(resource_builder)
             .build())

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -1,4 +1,4 @@
-use crate::plugins::{Plugin, PluginLoder};
+use crate::plugins::{Plugin, PluginLoader};
 
 use wolf_engine_core::ecs::systems::Resource;
 use wolf_engine_core::ecs::Resources;
@@ -7,14 +7,14 @@ use wolf_engine_core::Engine;
 
 pub struct FrameworkBuilder<E: UserEvent> {
     resources: Resources,
-    plugin_loader: PluginLoder<E>,
+    plugin_loader: PluginLoader<E>,
 }
 
 impl<E: UserEvent> FrameworkBuilder<E> {
     pub(crate) fn new() -> Self {
         Self {
             resources: Resources::default(),
-            plugin_loader: PluginLoder::new(),
+            plugin_loader: PluginLoader::new(),
         }
     }
 
@@ -29,7 +29,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
     }
 
     pub fn build(&mut self) -> Result<Engine<E>, String> {
-        let mut plugin_loader = std::mem::replace(&mut self.plugin_loader, PluginLoder::new());
+        let mut plugin_loader = std::mem::replace(&mut self.plugin_loader, PluginLoader::new());
         match plugin_loader.load_plugins(self) {
             Ok(_) => (),
             Err(error) => return Err(error),

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -1,0 +1,42 @@
+use crate::plugins::Plugin;
+
+use wolf_engine_core::ecs::systems::Resource;
+use wolf_engine_core::ecs::ResourcesBuilder;
+use wolf_engine_core::events::UserEvent;
+use wolf_engine_core::Engine;
+
+pub struct FrameworkBuilder<E: UserEvent> {
+    resource_builder: ResourcesBuilder,
+    plugins: Vec<Box<dyn Plugin<E>>>,
+}
+
+impl<E: UserEvent> FrameworkBuilder<E> {
+    pub(crate) fn new() -> Self {
+        Self {
+            plugins: Vec::new(),
+            resource_builder: ResourcesBuilder::default(),
+        }
+    }
+
+    pub fn with_plugin<P: Plugin<E> + 'static>(mut self, plugin: P) -> Self {
+        self.plugins.push(Box::from(plugin));
+        self
+    }
+
+    pub fn with_resource<T: Resource + 'static>(mut self, resource: T) -> Self {
+        self.resource_builder.add_resource(resource);
+        self
+    }
+
+    pub fn build(mut self) -> Engine<E> {
+        let plugins = std::mem::take(&mut self.plugins);
+
+        for mut plugin in plugins {
+            self = plugin.load(self).expect("Failed to load plugin");
+        }
+
+        wolf_engine_core::init()
+            .with_resources(self.resource_builder)
+            .build()
+    }
+}

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -28,13 +28,19 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         self
     }
 
-    pub fn build(&mut self) -> Engine<E> {
+    pub fn build(&mut self) -> Result<Engine<E>, String> {
         let mut plugin_loader = std::mem::replace(&mut self.plugin_loader, PluginLoder::new());
-        plugin_loader.load_plugins(self).expect("Failed to load plugins");
+        match plugin_loader.load_plugins(self) {
+            Ok(_) => (),
+            Err(error) => return Err(error),
+        } 
 
         let resource_builder = std::mem::take(&mut self.resource_builder);
-        wolf_engine_core::init()
-            .with_resources(resource_builder)
-            .build()
+
+        Ok(
+            wolf_engine_core::init()
+                .with_resources(resource_builder)
+                .build()
+        )
     }
 }

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -18,23 +18,23 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         }
     }
 
-    pub fn with_plugin<P: Plugin<E> + 'static>(mut self, plugin: P) -> Self {
+    pub fn with_plugin<P: Plugin<E> + 'static>(&mut self, plugin: P) -> &mut Self {
         self.plugin_loader.add_plugin(Box::from(plugin));
         self
     }
 
-    pub fn with_resource<T: Resource + 'static>(mut self, resource: T) -> Self {
+    pub fn with_resource<T: Resource + 'static>(&mut self, resource: T) -> &mut Self {
         self.resource_builder.add_resource(resource);
         self
     }
 
-    pub fn build(mut self) -> Engine<E> {
+    pub fn build(&mut self) -> Engine<E> {
         let mut plugin_loader = std::mem::replace(&mut self.plugin_loader, PluginLoder::new());
+        plugin_loader.load_plugins(self).expect("Failed to load plugins");
 
-        self = plugin_loader.load_plugins(self).expect("Failed to load plugins");
-
+        let resource_builder = std::mem::take(&mut self.resource_builder);
         wolf_engine_core::init()
-            .with_resources(self.resource_builder)
+            .with_resources(resource_builder)
             .build()
     }
 }

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -34,9 +34,9 @@ impl<E: UserEvent> FrameworkBuilder<E> {
             Ok(_) => (),
             Err(error) => return Err(error),
         }
-        let resource_builder = std::mem::take(&mut self.resources);
+        let resources = std::mem::take(&mut self.resources);
         Ok(wolf_engine_core::init()
-            .with_resources(resource_builder)
+            .with_resources(resources)
             .build())
     }
 }

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -29,9 +29,9 @@ impl<E: UserEvent> FrameworkBuilder<E> {
     }
 
     pub fn build(mut self) -> Engine<E> {
-        let plugin_loader = std::mem::take(&mut self.plugin_loader);
+        let mut plugin_loader = std::mem::replace(&mut self.plugin_loader, PluginLoder::new());
 
-        self = plugin_loader.load_plugins(self);
+        self = plugin_loader.load_plugins(self).expect("Failed to load plugins");
 
         wolf_engine_core::init()
             .with_resources(self.resource_builder)

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -14,7 +14,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
     pub(crate) fn new() -> Self {
         Self {
             resource_builder: ResourcesBuilder::default(),
-            plugin_loader: PluginLoder::new(), 
+            plugin_loader: PluginLoder::new(),
         }
     }
 
@@ -33,14 +33,10 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         match plugin_loader.load_plugins(self) {
             Ok(_) => (),
             Err(error) => return Err(error),
-        } 
-
+        }
         let resource_builder = std::mem::take(&mut self.resource_builder);
-
-        Ok(
-            wolf_engine_core::init()
-                .with_resources(resource_builder)
-                .build()
-        )
+        Ok(wolf_engine_core::init()
+            .with_resources(resource_builder)
+            .build())
     }
 }

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -23,7 +23,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         self
     }
 
-    pub fn with_resource<T: Resource + 'static>(&mut self, resource: T) -> &mut Self {
+    pub fn with_resource<T: Resource>(&mut self, resource: T) -> &mut Self {
         self.resources.insert(resource);
         self
     }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -56,13 +56,16 @@ pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
 
 #[cfg(test)]
 mod framework_init_tests {
-    pub struct TestResource;
+    pub struct TestResourceA;
+    pub struct TestResourceB;
 
     #[test]
     fn should_add_resources() {
         let (_event_loop, context) = crate::init::<()>()
-            .with_resource(TestResource)
+            .with_resource(TestResourceA)
+            .with_resource(TestResourceB)
             .build();
-        assert!(context.resources().get::<TestResource>().is_some(), "Resource insertion failed");
+        assert!(context.resources().get::<TestResourceA>().is_some(), "Resource insertion failed");
+        assert!(context.resources().get::<TestResourceB>().is_some(), "Resource insertion failed");
     }
 }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -35,7 +35,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
     }
 
     pub fn build(mut self) -> Engine<E> {
-        let plugins = std::mem::replace(&mut self.plugins, Vec::new());
+        let plugins = std::mem::take(&mut self.plugins);
 
         for mut plugin in plugins {
             self = plugin.load(self).expect("Failed to load plugin");

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -17,7 +17,7 @@ pub struct FrameworkBuilder<E: UserEvent> {
 }
 
 impl<E: UserEvent> FrameworkBuilder<E> {
-    pub(crate) fn new(engine_builder: EngineBuilder<E>) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             plugins: Vec::new(),
             resource_builder: ResourcesBuilder::default(),
@@ -48,7 +48,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
 }
 
 pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
-    FrameworkBuilder::<E>::new(wolf_engine_core::init())
+    FrameworkBuilder::<E>::new()
 }
 
 pub mod plugins {

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -12,7 +12,6 @@ use wolf_engine_core::{EngineBuilder, Engine};
 use wolf_engine_core::events::UserEvent;
 
 pub struct FrameworkBuilder<E: UserEvent> {
-    inner: EngineBuilder<E>,
     resource_builder: ResourcesBuilder,
     plugins: Vec<Box<dyn Plugin<E>>>,
 }
@@ -20,7 +19,6 @@ pub struct FrameworkBuilder<E: UserEvent> {
 impl<E: UserEvent> FrameworkBuilder<E> {
     pub(crate) fn new(engine_builder: EngineBuilder<E>) -> Self {
         Self {
-            inner: engine_builder,
             plugins: Vec::new(),
             resource_builder: ResourcesBuilder::default(),
         }
@@ -42,8 +40,10 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         for mut plugin in plugins {
             self = plugin.load(self).expect("Failed to load plugin");
         }
-
-        self.inner.build() 
+        
+        wolf_engine_core::init()
+            .with_resources(self.resource_builder)
+            .build()
     }
 }
 

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -8,9 +8,10 @@
 pub mod plugins;
 
 use plugins::Plugin;
+
+use wolf_engine_core::Engine;
 use wolf_engine_core::ecs::ResourcesBuilder;
 use wolf_engine_core::ecs::systems::Resource;
-use wolf_engine_core::Engine;
 use wolf_engine_core::events::UserEvent;
 
 pub struct FrameworkBuilder<E: UserEvent> {

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -8,7 +8,7 @@
 use plugins::Plugin;
 use wolf_engine_core::ecs::ResourcesBuilder;
 use wolf_engine_core::ecs::systems::Resource;
-use wolf_engine_core::{EngineBuilder, Engine};
+use wolf_engine_core::Engine;
 use wolf_engine_core::events::UserEvent;
 
 pub struct FrameworkBuilder<E: UserEvent> {

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -26,7 +26,8 @@ mod framework_init_tests {
         let (_event_loop, context) = crate::init::<()>()
             .with_resource(TestResourceA)
             .with_resource(TestResourceB)
-            .build();
+            .build()
+            .unwrap();
         assert!(
             context.resources().get::<TestResourceA>().is_some(),
             "Resource insertion failed"

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -12,7 +12,7 @@ pub mod plugins;
 
 use wolf_engine_core::events::UserEvent;
 
-/// Initializes Wolf Engine using the [FrameworkBuilder].
+/// Initializes Wolf Engine using the [`FrameworkBuilder`].
 pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
     FrameworkBuilder::<E>::new()
 }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -59,7 +59,7 @@ mod framework_init_tests {
     pub struct TestResource;
 
     #[test]
-    fn should_extend_default_init() {
+    fn should_add_resources() {
         let (_event_loop, context) = crate::init::<()>()
             .with_resource(TestResource)
             .build();

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -7,11 +7,13 @@
 
 use plugins::Plugin;
 use wolf_engine_core::ecs::ResourcesBuilder;
+use wolf_engine_core::ecs::systems::Resource;
 use wolf_engine_core::{EngineBuilder, Engine};
 use wolf_engine_core::events::UserEvent;
 
 pub struct FrameworkBuilder<E: UserEvent> {
     inner: EngineBuilder<E>,
+    resource_builder: ResourcesBuilder,
     plugins: Vec<Box<dyn Plugin<E>>>,
 }
 
@@ -20,6 +22,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         Self {
             inner: engine_builder,
             plugins: Vec::new(),
+            resource_builder: ResourcesBuilder::default(),
         }
     }
 
@@ -28,7 +31,8 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         self
     }
 
-    pub fn with_resource<T>(mut self, resource: T)-> Self {
+    pub fn with_resource<T: Resource + 'static>(mut self, resource: T)-> Self {
+        self.resource_builder.add_resource(resource);
         self
     }
 

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -12,6 +12,7 @@ pub mod plugins;
 
 use wolf_engine_core::events::UserEvent;
 
+/// Initializes Wolf Engine using the [FrameworkBuilder].
 pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
     FrameworkBuilder::<E>::new()
 }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -9,10 +9,10 @@ pub mod plugins;
 
 use plugins::Plugin;
 
-use wolf_engine_core::Engine;
-use wolf_engine_core::ecs::ResourcesBuilder;
 use wolf_engine_core::ecs::systems::Resource;
+use wolf_engine_core::ecs::ResourcesBuilder;
 use wolf_engine_core::events::UserEvent;
+use wolf_engine_core::Engine;
 
 pub struct FrameworkBuilder<E: UserEvent> {
     resource_builder: ResourcesBuilder,
@@ -28,11 +28,11 @@ impl<E: UserEvent> FrameworkBuilder<E> {
     }
 
     pub fn with_plugin<P: Plugin<E> + 'static>(mut self, plugin: P) -> Self {
-        self.plugins.push(Box::from(plugin));  
+        self.plugins.push(Box::from(plugin));
         self
     }
 
-    pub fn with_resource<T: Resource + 'static>(mut self, resource: T)-> Self {
+    pub fn with_resource<T: Resource + 'static>(mut self, resource: T) -> Self {
         self.resource_builder.add_resource(resource);
         self
     }
@@ -43,7 +43,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         for mut plugin in plugins {
             self = plugin.load(self).expect("Failed to load plugin");
         }
-        
+
         wolf_engine_core::init()
             .with_resources(self.resource_builder)
             .build()
@@ -65,7 +65,13 @@ mod framework_init_tests {
             .with_resource(TestResourceA)
             .with_resource(TestResourceB)
             .build();
-        assert!(context.resources().get::<TestResourceA>().is_some(), "Resource insertion failed");
-        assert!(context.resources().get::<TestResourceB>().is_some(), "Resource insertion failed");
+        assert!(
+            context.resources().get::<TestResourceA>().is_some(),
+            "Resource insertion failed"
+        );
+        assert!(
+            context.resources().get::<TestResourceB>().is_some(),
+            "Resource insertion failed"
+        );
     }
 }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -5,50 +5,12 @@
 //! more on building your game.  The framework includes a plugin system, and game state /
 //! state-stack architecture.
 
+mod framework_builder;
+pub use framework_builder::*;
+
 pub mod plugins;
 
-use plugins::Plugin;
-
-use wolf_engine_core::ecs::systems::Resource;
-use wolf_engine_core::ecs::ResourcesBuilder;
 use wolf_engine_core::events::UserEvent;
-use wolf_engine_core::Engine;
-
-pub struct FrameworkBuilder<E: UserEvent> {
-    resource_builder: ResourcesBuilder,
-    plugins: Vec<Box<dyn Plugin<E>>>,
-}
-
-impl<E: UserEvent> FrameworkBuilder<E> {
-    pub(crate) fn new() -> Self {
-        Self {
-            plugins: Vec::new(),
-            resource_builder: ResourcesBuilder::default(),
-        }
-    }
-
-    pub fn with_plugin<P: Plugin<E> + 'static>(mut self, plugin: P) -> Self {
-        self.plugins.push(Box::from(plugin));
-        self
-    }
-
-    pub fn with_resource<T: Resource + 'static>(mut self, resource: T) -> Self {
-        self.resource_builder.add_resource(resource);
-        self
-    }
-
-    pub fn build(mut self) -> Engine<E> {
-        let plugins = std::mem::take(&mut self.plugins);
-
-        for mut plugin in plugins {
-            self = plugin.load(self).expect("Failed to load plugin");
-        }
-
-        wolf_engine_core::init()
-            .with_resources(self.resource_builder)
-            .build()
-    }
-}
 
 pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
     FrameworkBuilder::<E>::new()

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -55,7 +55,7 @@ pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
 }
 
 #[cfg(test)]
-mod framework_tests {
+mod framework_init_tests {
     pub struct TestResource;
 
     #[test]

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -28,8 +28,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         self
     }
 
-    pub fn with_resources(mut self, function: fn(&mut ResourcesBuilder)) -> Self {
-        self.inner = self.inner.with_resources(function);
+    pub fn with_resource<T>(mut self, resource: T)-> Self {
         self
     }
 
@@ -84,9 +83,7 @@ pub mod plugins {
         impl<E: UserEvent> Plugin<E> for TestPlugin<E> {
             fn load(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E> {
                 Ok(
-                    builder.with_resources(|resources| {
-                        resources.add_resource(TestResource);
-                    })
+                    builder.with_resource(TestResource)
                 )
             }
         }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -5,6 +5,8 @@
 //! more on building your game.  The framework includes a plugin system, and game state /
 //! state-stack architecture.
 
+pub mod plugins;
+
 use plugins::Plugin;
 use wolf_engine_core::ecs::ResourcesBuilder;
 use wolf_engine_core::ecs::systems::Resource;
@@ -49,57 +51,6 @@ impl<E: UserEvent> FrameworkBuilder<E> {
 
 pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
     FrameworkBuilder::<E>::new()
-}
-
-pub mod plugins {
-    use crate::FrameworkBuilder; 
-    use wolf_engine_core::events::UserEvent;
-    
-    pub type PluginResult<E> = Result<FrameworkBuilder<E>, String>;
-
-    pub trait Plugin<E: UserEvent> {
-        fn load(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E>;
-    }
-
-    #[cfg(test)]
-    mod plugin_loader_tests {
-        use super::*;
-        use crate::FrameworkBuilder;
-
-        use std::marker::PhantomData;
-
-        use wolf_engine_core::events::UserEvent;
-
-        pub struct TestResource;
-
-        pub struct TestPlugin<E: UserEvent> {
-            _phantom: PhantomData<E>,
-        }
-
-        impl<E: UserEvent> TestPlugin<E> {
-            pub fn new() -> Self {
-                Self {
-                    _phantom: PhantomData::default(), 
-                }
-            }
-        }
-
-        impl<E: UserEvent> Plugin<E> for TestPlugin<E> {
-            fn load(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E> {
-                Ok(
-                    builder.with_resource(TestResource)
-                )
-            }
-        }
-
-        #[test]
-        fn should_load_plugins() {
-            let (_event_loop, context) = crate::init::<()>()
-                .with_plugin(TestPlugin::new())
-                .build();
-            assert!(context.resources().get::<TestResource>().is_some(), "Resource insertion failed");
-        }
-    }
 }
 
 #[cfg(test)]

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -2,10 +2,10 @@ use crate::FrameworkBuilder;
 
 use wolf_engine_core::events::UserEvent;
 
-pub type PluginResult<E> = Result<FrameworkBuilder<E>, String>;
+pub type PluginResult = Result<(), String>;
 
 pub trait Plugin<E: UserEvent> {
-    fn load(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E>;
+    fn load(&mut self, builder: &mut FrameworkBuilder<E>) -> PluginResult;
 }
 
 pub(crate) struct PluginLoder<E: UserEvent> {
@@ -21,11 +21,11 @@ impl<E: UserEvent> PluginLoder<E> {
         self.plugins.push(plugin); 
     }
 
-    pub fn load_plugins(&mut self, mut builder: FrameworkBuilder<E>) -> PluginResult<E> {
+    pub fn load_plugins(&mut self, builder: &mut FrameworkBuilder<E>) -> PluginResult {
         for plugin in &mut self.plugins {
-            builder = plugin.load(builder).expect("Failed to load plugin");
+            plugin.load(builder).expect("Failed to load plugin");
         }
-        Ok(builder)
+        Ok(())
     }
 }
 
@@ -52,8 +52,9 @@ mod plugin_loader_tests {
     }
 
     impl<E: UserEvent> Plugin<E> for TestPlugin<E> {
-        fn load(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E> {
-            Ok(builder.with_resource(TestResource))
+        fn load(&mut self, builder: &mut FrameworkBuilder<E>) -> PluginResult {
+            builder.with_resource(TestResource);
+            Ok(())
         }
     }
 

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -18,10 +18,13 @@ impl<E: UserEvent> PluginLoder<E> {
     }
 
     pub fn add_plugin(&mut self, plugin: Box<dyn Plugin<E> + 'static>) {
-        
+        self.plugins.push(plugin); 
     }
 
-    pub fn load_plugins(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E> {
+    pub fn load_plugins(&mut self, mut builder: FrameworkBuilder<E>) -> PluginResult<E> {
+        for plugin in &mut self.plugins {
+            builder = plugin.load(builder).expect("Failed to load plugin");
+        }
         Ok(builder)
     }
 }

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -23,7 +23,11 @@ impl<E: UserEvent> PluginLoder<E> {
 
     pub fn load_plugins(&mut self, builder: &mut FrameworkBuilder<E>) -> PluginResult {
         for plugin in &mut self.plugins {
-            plugin.load(builder).expect("Failed to load plugin");
+            match plugin.load(builder) {
+                Ok(_) => (),
+                Err(error) => 
+                    return Err(format!("Error loading Plugin ({}): ", plugin.name(), error)),
+            }
         }
         Ok(())
     }

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -46,11 +46,8 @@ impl<E: UserEvent> PluginLoader<E> {
             match plugin.load(builder) {
                 Ok(_) => (),
                 Err(error) => {
-                    let error_message = format!(
-                        "Error loading Plugin ({}): {}",
-                        plugin.name(),
-                        error
-                    );
+                    let error_message =
+                        format!("Error loading Plugin ({}): {}", plugin.name(), error);
                     log::error!("{}", error_message);
                     return Err(error);
                 }

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -8,6 +8,20 @@ pub trait Plugin<E: UserEvent> {
     fn load(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E>;
 }
 
+pub(crate) struct PluginLoder<E: UserEvent> {
+    plugins: Vec<Box<dyn Plugin<E>>>,
+}
+
+impl<E: UserEvent> PluginLoder<E> {
+    pub fn new() -> Self {
+        Self { plugins: Vec::new() }
+    }
+
+    pub fn add_plugin(&mut self, plugin: Box<dyn Plugin<E> + 'static>) {
+        
+    }
+}
+
 #[cfg(test)]
 mod plugin_loader_tests {
     use super::*;

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -9,11 +9,11 @@ pub trait Plugin<E: UserEvent> {
     fn load(&mut self, builder: &mut FrameworkBuilder<E>) -> PluginResult;
 }
 
-pub(crate) struct PluginLoder<E: UserEvent> {
+pub(crate) struct PluginLoader<E: UserEvent> {
     plugins: Vec<Box<dyn Plugin<E>>>,
 }
 
-impl<E: UserEvent> PluginLoder<E> {
+impl<E: UserEvent> PluginLoader<E> {
     pub fn new() -> Self {
         Self {
             plugins: Vec::new(),

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -69,7 +69,10 @@ mod plugin_loader_tests {
 
     #[test]
     fn should_load_plugins() {
-        let (_event_loop, context) = crate::init::<()>().with_plugin(TestPlugin::new()).build();
+        let (_event_loop, context) = crate::init::<()>()
+            .with_plugin(TestPlugin::new())
+            .build()
+            .unwrap();
         assert!(
             context.resources().get::<TestResource>().is_some(),
             "Resource insertion failed"

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -15,19 +15,26 @@ pub(crate) struct PluginLoder<E: UserEvent> {
 
 impl<E: UserEvent> PluginLoder<E> {
     pub fn new() -> Self {
-        Self { plugins: Vec::new() }
+        Self {
+            plugins: Vec::new(),
+        }
     }
 
     pub fn add_plugin(&mut self, plugin: Box<dyn Plugin<E> + 'static>) {
-        self.plugins.push(plugin); 
+        self.plugins.push(plugin);
     }
 
     pub fn load_plugins(&mut self, builder: &mut FrameworkBuilder<E>) -> PluginResult {
         for plugin in &mut self.plugins {
             match plugin.load(builder) {
                 Ok(_) => (),
-                Err(error) => 
-                    return Err(format!("Error loading Plugin ({}): {}", plugin.name(), error)),
+                Err(error) => {
+                    return Err(format!(
+                        "Error loading Plugin ({}): {}",
+                        plugin.name(),
+                        error
+                    ))
+                }
             }
         }
         Ok(())

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -96,13 +96,9 @@ mod plugin_loader_tests {
 
     #[test]
     fn should_handle_plugin_failures() {
-        let (_event_loop, context) = crate::init::<()>()
+        let result = crate::init::<()>()
             .with_plugin(TestPlugin::new(true))
-            .build()
-            .unwrap();
-        assert!(
-            context.resources().get::<TestResource>().is_some(),
-            "Resource insertion failed"
-        );
+            .build();
+        assert!(result.is_err(), "The build should have failed");
     }
 }

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -2,7 +2,7 @@ use crate::FrameworkBuilder;
 
 use wolf_engine_core::events::UserEvent;
 
-pub type PluginResult<E> = Result<FrameworkBuilder<E>, (FrameworkBuilder<E>, String)>;
+pub type PluginResult<E> = Result<FrameworkBuilder<E>, String>;
 
 pub trait Plugin<E: UserEvent> {
     fn load(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E>;

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -20,6 +20,10 @@ impl<E: UserEvent> PluginLoder<E> {
     pub fn add_plugin(&mut self, plugin: Box<dyn Plugin<E> + 'static>) {
         
     }
+
+    pub fn load_plugins(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E> {
+        Ok(builder)
+    }
 }
 
 #[cfg(test)]

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -1,5 +1,5 @@
-
 use crate::FrameworkBuilder; 
+
 use wolf_engine_core::events::UserEvent;
 
 pub type PluginResult<E> = Result<FrameworkBuilder<E>, String>;

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -11,7 +11,6 @@ pub trait Plugin<E: UserEvent> {
 #[cfg(test)]
 mod plugin_loader_tests {
     use super::*;
-    use crate::FrameworkBuilder;
 
     use std::marker::PhantomData;
 

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -27,7 +27,7 @@ impl<E: UserEvent> PluginLoder<E> {
             match plugin.load(builder) {
                 Ok(_) => (),
                 Err(error) => 
-                    return Err(format!("Error loading Plugin ({}): ", plugin.name(), error)),
+                    return Err(format!("Error loading Plugin ({}): {}", plugin.name(), error)),
             }
         }
         Ok(())

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -1,4 +1,4 @@
-use crate::FrameworkBuilder; 
+use crate::FrameworkBuilder;
 
 use wolf_engine_core::events::UserEvent;
 
@@ -25,24 +25,23 @@ mod plugin_loader_tests {
     impl<E: UserEvent> TestPlugin<E> {
         pub fn new() -> Self {
             Self {
-                _event_type: PhantomData, 
+                _event_type: PhantomData,
             }
         }
     }
 
     impl<E: UserEvent> Plugin<E> for TestPlugin<E> {
         fn load(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E> {
-            Ok(
-                builder.with_resource(TestResource)
-            )
+            Ok(builder.with_resource(TestResource))
         }
     }
 
     #[test]
     fn should_load_plugins() {
-        let (_event_loop, context) = crate::init::<()>()
-            .with_plugin(TestPlugin::new())
-            .build();
-        assert!(context.resources().get::<TestResource>().is_some(), "Resource insertion failed");
+        let (_event_loop, context) = crate::init::<()>().with_plugin(TestPlugin::new()).build();
+        assert!(
+            context.resources().get::<TestResource>().is_some(),
+            "Resource insertion failed"
+        );
     }
 }

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -1,0 +1,49 @@
+
+use crate::FrameworkBuilder; 
+use wolf_engine_core::events::UserEvent;
+
+pub type PluginResult<E> = Result<FrameworkBuilder<E>, String>;
+
+pub trait Plugin<E: UserEvent> {
+    fn load(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E>;
+}
+
+#[cfg(test)]
+mod plugin_loader_tests {
+    use super::*;
+    use crate::FrameworkBuilder;
+
+    use std::marker::PhantomData;
+
+    use wolf_engine_core::events::UserEvent;
+
+    pub struct TestResource;
+
+    pub struct TestPlugin<E: UserEvent> {
+        _phantom: PhantomData<E>,
+    }
+
+    impl<E: UserEvent> TestPlugin<E> {
+        pub fn new() -> Self {
+            Self {
+                _phantom: PhantomData::default(), 
+            }
+        }
+    }
+
+    impl<E: UserEvent> Plugin<E> for TestPlugin<E> {
+        fn load(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E> {
+            Ok(
+                builder.with_resource(TestResource)
+            )
+        }
+    }
+
+    #[test]
+    fn should_load_plugins() {
+        let (_event_loop, context) = crate::init::<()>()
+            .with_plugin(TestPlugin::new())
+            .build();
+        assert!(context.resources().get::<TestResource>().is_some(), "Resource insertion failed");
+    }
+}

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -25,7 +25,7 @@ mod plugin_loader_tests {
     impl<E: UserEvent> TestPlugin<E> {
         pub fn new() -> Self {
             Self {
-                _phantom: PhantomData::default(), 
+                _phantom: PhantomData, 
             }
         }
     }

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -2,7 +2,7 @@ use crate::FrameworkBuilder;
 
 use wolf_engine_core::events::UserEvent;
 
-pub type PluginResult<E> = Result<FrameworkBuilder<E>, String>;
+pub type PluginResult<E> = Result<FrameworkBuilder<E>, (FrameworkBuilder<E>, String)>;
 
 pub trait Plugin<E: UserEvent> {
     fn load(&mut self, builder: FrameworkBuilder<E>) -> PluginResult<E>;

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -5,6 +5,7 @@ use wolf_engine_core::events::UserEvent;
 pub type PluginResult = Result<(), String>;
 
 pub trait Plugin<E: UserEvent> {
+    fn name(&self) -> &str;
     fn load(&mut self, builder: &mut FrameworkBuilder<E>) -> PluginResult;
 }
 
@@ -59,6 +60,10 @@ mod plugin_loader_tests {
         fn load(&mut self, builder: &mut FrameworkBuilder<E>) -> PluginResult {
             builder.with_resource(TestResource);
             Ok(())
+        }
+
+        fn name(&self) -> &str {
+            "Test Plugin"
         }
     }
 

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -19,13 +19,13 @@ mod plugin_loader_tests {
     pub struct TestResource;
 
     pub struct TestPlugin<E: UserEvent> {
-        _phantom: PhantomData<E>,
+        _event_type: PhantomData<E>,
     }
 
     impl<E: UserEvent> TestPlugin<E> {
         pub fn new() -> Self {
             Self {
-                _phantom: PhantomData, 
+                _event_type: PhantomData, 
             }
         }
     }

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -1,3 +1,5 @@
+//! Provides a plugin system for the engine.
+
 use crate::FrameworkBuilder;
 
 use wolf_engine_core::events::UserEvent;

--- a/wolf_engine_framework/src/plugins.rs
+++ b/wolf_engine_framework/src/plugins.rs
@@ -4,10 +4,25 @@ use crate::FrameworkBuilder;
 
 use wolf_engine_core::events::UserEvent;
 
+/// A result type for the plugin system.
 pub type PluginResult = Result<(), String>;
 
+/// A module which adds new functionality to the engine.
 pub trait Plugin<E: UserEvent> {
+    /// Returns a people-friendly name for the plugin.
+    ///
+    /// This is mostly used to identify the plugin in logs.  There aren't any specific requirements
+    /// for what the name should be, and it may change, so you probably shouldn't use this to
+    /// uniquely identify plugins.
     fn name(&self) -> &str;
+
+    /// Loads the plugin using the provided [`FrameworkBuilder`].
+    ///
+    /// The plugin does all setup here.
+    ///
+    /// **Note:** Plugins shouldn't try to load other plugins using the builder.  At this point in
+    /// the setup process, it's not possible to add additional plugins.  Nothing will happen if you
+    /// try.
     fn load(&mut self, builder: &mut FrameworkBuilder<E>) -> PluginResult;
 }
 


### PR DESCRIPTION
This PR introduces the basics of the plugin system.  It also adds the `framework::init()` function, and updates the `EngineBuilder` to reduce code duplication.

# Changes Made

All notable changes introduced by this PR should be documented here.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

- Added `framework::init()` function.
- Added `FrameworkBuilder`.
- Added `framework::plugins` module.
- Added `Plugin` trait.
- Added `plugins` example.

- Changed `EngineBuilder::with_resources()` to take `Resources`, rather than a `fn(ResourcesBuilder)`.

- Removed `ContextBuilder`.
- Removed `ResourcesBuilder`.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR
can be accepted.

- [x] New behaviors are covered by tests, and / or examples.
- [x] The documentation has been updated (if applicable.)
- [x] The version number has been bumped (if applicable.)
- [x] The feature branch is up to date with `main`. 
