### PR TITLE
Feature: Customizable `MainLoop` API

### DIFF
--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -40,7 +40,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         self
     }
 
-    pub fn with_main_loop<T: MainLoop>(&mut self, main_loop: T) -> &mut Self {
+    pub fn with_main_loop<T: MainLoop<E>>(&mut self, main_loop: T) -> &mut Self {
         self
     }
 

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -39,6 +39,10 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         self
     }
 
+    pub fn with_main_loop<T: MainLoop>(&mut self, main_loop: T) -> &mut Self {
+    
+    }
+
     /// Creates a new instance of [`Engine`] from the builder.
     pub fn build(&mut self) -> Result<Engine<E>, String> {
         let mut plugin_loader = std::mem::replace(&mut self.plugin_loader, PluginLoader::new());

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -1,3 +1,4 @@
+use crate::MainLoop;
 use crate::plugins::{Plugin, PluginLoader};
 
 use wolf_engine_core::ecs::systems::Resource;
@@ -40,7 +41,7 @@ impl<E: UserEvent> FrameworkBuilder<E> {
     }
 
     pub fn with_main_loop<T: MainLoop>(&mut self, main_loop: T) -> &mut Self {
-    
+        self
     }
 
     /// Creates a new instance of [`Engine`] from the builder.

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -1,4 +1,4 @@
-use crate::MainLoop;
+use crate::{MainLoop, MainLoopResource};
 use crate::plugins::{Plugin, PluginLoader};
 
 use wolf_engine_core::ecs::systems::Resource;
@@ -40,7 +40,10 @@ impl<E: UserEvent> FrameworkBuilder<E> {
         self
     }
 
-    pub fn with_main_loop<T: MainLoop<E>>(&mut self, main_loop: T) -> &mut Self {
+    pub fn with_main_loop<T: MainLoop<E> + 'static>(&mut self, main_loop: T) -> &mut Self {
+        self.resources.get_mut::<MainLoopResource<E>>()
+            .expect("No MainLoop resource.  This is a bug.")
+            .set_main_loop(Box::from(main_loop));
         self
     }
 

--- a/wolf_engine_framework/src/framework_builder.rs
+++ b/wolf_engine_framework/src/framework_builder.rs
@@ -1,5 +1,5 @@
-use crate::{MainLoop, MainLoopResource};
 use crate::plugins::{Plugin, PluginLoader};
+use crate::{MainLoop, MainLoopResource};
 
 use wolf_engine_core::ecs::systems::Resource;
 use wolf_engine_core::ecs::Resources;
@@ -41,7 +41,8 @@ impl<E: UserEvent> FrameworkBuilder<E> {
     }
 
     pub fn with_main_loop<T: MainLoop<E> + 'static>(&mut self, main_loop: T) -> &mut Self {
-        self.resources.get_mut::<MainLoopResource<E>>()
+        self.resources
+            .get_mut::<MainLoopResource<E>>()
             .expect("No MainLoop resource.  This is a bug.")
             .set_main_loop(Box::from(main_loop));
         self

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -58,6 +58,7 @@ impl<E: UserEvent> MainLoopResource<E> {
     }
 }
 
+#[cfg_attr(test, mockall::automock)]
 pub trait MainLoop<E: UserEvent> {
     fn run(&mut self, engine: Engine<E>);
 }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -21,29 +21,6 @@ pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
     builder
 }
 
-/// Runs the [`Engine`].
-///
-/// # Panics
-///
-/// This function expects you to use the Framework's [wolf_enigne::framework::init()](init)
-/// function to create the [`Engine`], otherwise, this function will panic.
-pub fn run<E: UserEvent>(engine: Engine<E>) {
-    let (event_loop, mut context) = engine;
-
-    let mut main_loop = context.resources_mut()
-        .remove::<MainLoopResource<E>>()
-        .expect(
-            "No main loop.  Make sure you used `wolf_engine::framework::init()` to set up the Engine")
-        .extract();
-
-    main_loop.run((event_loop, context));
-}
-
-/// The default [`MainLoop`] implementation.
-pub(crate) fn main_loop<E: UserEvent>(_engine: Engine<E>) {
-    todo!("Will be implemented with the Scene system.")
-}
-
 #[cfg(test)]
 mod framework_init_tests {
     pub struct TestResourceA;
@@ -65,6 +42,29 @@ mod framework_init_tests {
             "Resource insertion failed"
         );
     }
+}
+
+/// Runs the [`Engine`].
+///
+/// # Panics
+///
+/// This function expects you to use the Framework's [wolf_enigne::framework::init()](init)
+/// function to create the [`Engine`], otherwise, this function will panic.
+pub fn run<E: UserEvent>(engine: Engine<E>) {
+    let (event_loop, mut context) = engine;
+
+    let mut main_loop = context.resources_mut()
+        .remove::<MainLoopResource<E>>()
+        .expect(
+            "No main loop.  Make sure you used `wolf_engine::framework::init()` to set up the Engine")
+        .extract();
+
+    main_loop.run((event_loop, context));
+}
+
+/// The default [`MainLoop`] implementation.
+pub(crate) fn main_loop<E: UserEvent>(_engine: Engine<E>) {
+    todo!("Will be implemented with the Scene system.")
 }
 
 #[cfg(test)]

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -39,3 +39,18 @@ mod framework_init_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod framework_runner_test {
+    #[test]
+    fn should_add_main_loop_resource() {
+        let (_event_loop, context) = crate::init::<()>()
+            .build()
+            .unwrap();
+
+        assert!(
+            context.resources().get::<MainLoop>().is_some(),
+            "Main loop resource was not inserted"
+        );
+    }
+}

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -21,6 +21,12 @@ pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
     builder
 }
 
+/// Runs the [`Engine`].
+///
+/// # Panics
+///
+/// This function expects you to use the Framework's [wolf_enigne::framework::init()](init)
+/// function to create the [`Engine`], otherwise, this function will panic.
 pub fn run<E: UserEvent>(engine: Engine<E>) {
     let (event_loop, mut context) = engine;
 
@@ -33,6 +39,7 @@ pub fn run<E: UserEvent>(engine: Engine<E>) {
     main_loop.run((event_loop, context));
 }
 
+/// The default [`MainLoop`] implementation.
 pub(crate) fn main_loop<E: UserEvent>(engine: Engine<E>) {}
 
 #[cfg(test)]
@@ -58,22 +65,28 @@ mod framework_init_tests {
     }
 }
 
+/// Provides a wrapper around some [`MainLoop`] implementation, making it possible to access it as
+/// a [`Resource`] at run-time.
 pub(crate) struct MainLoopResource<E: UserEvent> {
     inner: Box<dyn MainLoop<E>>,
 }
 
 impl<E: UserEvent> MainLoopResource<E> {
+    /// Sets the inner [`MainLoop`].
     pub fn set_main_loop(&mut self, main_loop: Box<dyn MainLoop<E>>) {
         self.inner = main_loop;
     }
-
+    
+    /// Consumes the resource, and returns a pointer to underlying [`MainLoop`].
     pub fn extract(self) -> Box<dyn MainLoop<E>> {
         self.inner
     }
 }
 
+/// An implementation of the engine's main-loop.
 #[cfg_attr(test, mockall::automock)]
 pub trait MainLoop<E: UserEvent> {
+    /// Runs the main-loop until the engine quits.
     fn run(&mut self, engine: Engine<E>);
 }
 

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -115,4 +115,13 @@ mod framework_runner_test {
 
         crate::run(engine);
     }
+
+    #[test]
+    #[should_panic]
+    fn should_panic_without_main_loop() {
+        let engine = wolf_engine_core::init::<()>()
+            .build();
+
+        crate::run(engine);
+    }
 }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -22,7 +22,14 @@ pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
 }
 
 pub fn run<E: UserEvent>(mut engine: Engine<E>) {
-    
+    let (event_loop, mut context) = engine;  
+
+    let mut main_loop = context.resources_mut()
+        .remove::<MainLoopResource<E>>()
+        .expect("No main loop.  Make sure you used `framework::init()` to set up the Engine")
+        .extract();
+
+    main_loop.run((event_loop, context));
 }
 
 #[cfg(test)]

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -21,6 +21,10 @@ pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
     builder
 }
 
+pub fn run<E: UserEvent>(mut engine: Engine<E>) {
+    
+}
+
 #[cfg(test)]
 mod framework_init_tests {
     pub struct TestResourceA;

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -14,7 +14,9 @@ use wolf_engine_core::events::UserEvent;
 
 /// Initializes Wolf Engine using the [`FrameworkBuilder`].
 pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
-    FrameworkBuilder::<E>::new()
+    let mut builder = FrameworkBuilder::<E>::new();
+    builder.with_resource(MainLoopResource{});
+    builder
 }
 
 #[cfg(test)]

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -46,8 +46,12 @@ pub(crate) struct MainLoopResource {
      
 }
 
-pub trait MainLoop {
-    
+pub trait MainLoop<E: UserEvent> {
+     
+}
+
+impl<E: UserEvent, T> MainLoop<E> for T where T: FnOnce(Engine<E>) {
+
 }
 
 #[cfg(test)]

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -47,11 +47,13 @@ pub(crate) struct MainLoopResource {
 }
 
 pub trait MainLoop<E: UserEvent> {
-     
+    fn run(self, engine: Engine<E>);
 }
 
 impl<E: UserEvent, T> MainLoop<E> for T where T: FnOnce(Engine<E>) {
-
+    fn run(self, engine: Engine<E>) {
+        (self)(engine)
+    }
 }
 
 #[cfg(test)]

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -15,9 +15,7 @@ use wolf_engine_core::{events::UserEvent, Engine};
 /// Initializes Wolf Engine using the [`FrameworkBuilder`].
 pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
     let mut builder = FrameworkBuilder::<E>::new();
-    builder.with_resource(MainLoopResource::<E> {
-        inner: Box::from(main_loop),
-    });
+    builder.with_resource(MainLoopResource::<E>::new(main_loop));
     builder
 }
 
@@ -72,6 +70,13 @@ pub(crate) struct MainLoopResource<E: UserEvent> {
 }
 
 impl<E: UserEvent> MainLoopResource<E> {
+    /// Creates a new resource from the provided [`MainLoop`].
+    pub fn new<L: MainLoop<E> + 'static>(main_loop: L) -> Self {
+        Self {
+            inner: Box::from(main_loop),
+        }
+    }
+
     /// Sets the inner [`MainLoop`].
     pub fn set_main_loop(&mut self, main_loop: Box<dyn MainLoop<E>>) {
         self.inner = main_loop;

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -48,18 +48,18 @@ pub(crate) struct MainLoopResource<E: UserEvent> {
     inner: Box<dyn MainLoop<E>>,
 }
 
-impl<E: UserEvent> MainLoop<E> for MainLoopResource<E> {
-    fn run(self, engine: Engine<E>) {
-        todo!()
+impl<E: UserEvent> MainLoopResource<E> {
+    pub fn extract(self) -> Box<dyn MainLoop<E>> {
+        self.inner 
     }
 }
 
 pub trait MainLoop<E: UserEvent> {
-    fn run(self, engine: Engine<E>);
+    fn run(&mut self, engine: Engine<E>);
 }
 
-impl<E: UserEvent, T> MainLoop<E> for T where T: FnOnce(Engine<E>) {
-    fn run(self, engine: Engine<E>) {
+impl<E: UserEvent, T> MainLoop<E> for T where T: FnMut(Engine<E>) {
+    fn run(&mut self, engine: Engine<E>) {
         (self)(engine)
     }
 }
@@ -87,9 +87,10 @@ mod framework_runner_test {
             .build()
             .unwrap();
 
-        let main_loop = context.resources_mut()
+        let mut main_loop = context.resources_mut()
             .remove::<MainLoopResource<()>>()
-            .expect("No MainLoopResource");
+            .expect("No MainLoopResource")
+            .extract();
 
         main_loop.run((event_loop, context));
     }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -88,6 +88,9 @@ mod framework_runner_test {
     #[test]
     fn should_add_custom_main_loop() {
         let mut mock_main_loop = MockMainLoop::new();
+        mock_main_loop.expect_run()
+            .once()
+            .return_const(());
 
         let (event_loop, mut context) = crate::init::<()>()
             .with_main_loop(mock_main_loop)

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -86,21 +86,17 @@ mod framework_runner_test {
 
     #[test]
     fn should_add_custom_main_loop() {
-        let mut has_run = false;
+        let mut mock_main_loop = MockMainLoop::new();
+
         let (event_loop, mut context) = crate::init::<()>()
-            .with_main_loop(|engine| {
-                has_run = true;
-            })
+            .with_main_loop(mock_main_loop)
             .build()
             .unwrap();
-
         let mut main_loop = context.resources_mut()
             .remove::<MainLoopResource<()>>()
             .expect("No MainLoopResource")
             .extract();
 
         main_loop.run((event_loop, context));
-
-        assert!(has_run, "The main loop did not run, or was not correct");
     }
 }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -12,7 +12,8 @@ pub use main_loop::*;
 
 pub mod plugins;
 
-use wolf_engine_core::{events::UserEvent, Engine};
+use wolf_engine_core::events::UserEvent;
+use wolf_engine_core::Engine;
 
 /// Initializes Wolf Engine using the [`FrameworkBuilder`].
 pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -92,15 +92,11 @@ mod framework_runner_test {
             .once()
             .return_const(());
 
-        let (event_loop, mut context) = crate::init::<()>()
+        let engine = crate::init::<()>()
             .with_main_loop(mock_main_loop)
             .build()
             .unwrap();
-        let mut main_loop = context.resources_mut()
-            .remove::<MainLoopResource<()>>()
-            .expect("No MainLoopResource")
-            .extract();
 
-        main_loop.run((event_loop, context));
+        crate::run(engine);
     }
 }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -49,6 +49,10 @@ pub(crate) struct MainLoopResource<E: UserEvent> {
 }
 
 impl<E: UserEvent> MainLoopResource<E> {
+    pub fn set_main_loop(&mut self, main_loop: Box<dyn MainLoop<E>>) {
+        self.inner = main_loop;
+    }
+
     pub fn extract(self) -> Box<dyn MainLoop<E>> {
         self.inner 
     }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -40,8 +40,14 @@ mod framework_init_tests {
     }
 }
 
+pub(crate) struct MainLoopResource {
+     
+}
+
 #[cfg(test)]
 mod framework_runner_test {
+    use super::*;
+
     #[test]
     fn should_add_main_loop_resource() {
         let (_event_loop, context) = crate::init::<()>()

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -61,4 +61,12 @@ mod framework_runner_test {
             "Main loop resource was not inserted"
         );
     }
+
+    #[test]
+    fn should_add_custom_main_loop() {
+        let (_event_loop, context) = crate::init::<()>()
+            .with_main_loop(|engine| {})
+            .build()
+            .unwrap();
+    }
 }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -21,7 +21,7 @@ pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
     builder
 }
 
-pub fn run<E: UserEvent>(mut engine: Engine<E>) {
+pub fn run<E: UserEvent>(engine: Engine<E>) {
     let (event_loop, mut context) = engine;  
 
     let mut main_loop = context.resources_mut()

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -82,8 +82,11 @@ mod framework_runner_test {
 
     #[test]
     fn should_add_custom_main_loop() {
+        let mut has_run = false;
         let (event_loop, mut context) = crate::init::<()>()
-            .with_main_loop(|engine| {})
+            .with_main_loop(|engine| {
+                has_run = true;
+            })
             .build()
             .unwrap();
 
@@ -93,5 +96,7 @@ mod framework_runner_test {
             .extract();
 
         main_loop.run((event_loop, context));
+
+        assert!(has_run, "The main loop did not run, or was not correct");
     }
 }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -40,7 +40,9 @@ pub fn run<E: UserEvent>(engine: Engine<E>) {
 }
 
 /// The default [`MainLoop`] implementation.
-pub(crate) fn main_loop<E: UserEvent>(engine: Engine<E>) {}
+pub(crate) fn main_loop<E: UserEvent>(_engine: Engine<E>) {
+    todo!("Will be implemented with the Scene system.")
+}
 
 #[cfg(test)]
 mod framework_init_tests {

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -7,6 +7,8 @@
 
 mod framework_builder;
 pub use framework_builder::*;
+mod main_loop;
+pub use main_loop::*;
 
 pub mod plugins;
 
@@ -60,47 +62,6 @@ mod framework_init_tests {
             context.resources().get::<TestResourceB>().is_some(),
             "Resource insertion failed"
         );
-    }
-}
-
-/// Provides a wrapper around some [`MainLoop`] implementation, making it possible to access it as
-/// a [`Resource`] at run-time.
-pub(crate) struct MainLoopResource<E: UserEvent> {
-    inner: Box<dyn MainLoop<E>>,
-}
-
-impl<E: UserEvent> MainLoopResource<E> {
-    /// Creates a new resource from the provided [`MainLoop`].
-    pub fn new<L: MainLoop<E> + 'static>(main_loop: L) -> Self {
-        Self {
-            inner: Box::from(main_loop),
-        }
-    }
-
-    /// Sets the inner [`MainLoop`].
-    pub fn set_main_loop(&mut self, main_loop: Box<dyn MainLoop<E>>) {
-        self.inner = main_loop;
-    }
-    
-    /// Consumes the resource, and returns a pointer to underlying [`MainLoop`].
-    pub fn extract(self) -> Box<dyn MainLoop<E>> {
-        self.inner
-    }
-}
-
-/// An implementation of the engine's main-loop.
-#[cfg_attr(test, mockall::automock)]
-pub trait MainLoop<E: UserEvent> {
-    /// Runs the main-loop until the engine quits.
-    fn run(&mut self, engine: Engine<E>);
-}
-
-impl<E: UserEvent, T> MainLoop<E> for T
-where
-    T: FnMut(Engine<E>),
-{
-    fn run(&mut self, engine: Engine<E>) {
-        (self)(engine)
     }
 }
 

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -16,7 +16,7 @@ use wolf_engine_core::{events::UserEvent, Engine};
 pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
     let mut builder = FrameworkBuilder::<E>::new();
     builder.with_resource(MainLoopResource::<E> {
-        inner: Box::from(|_engine| {}),
+        inner: Box::from(main_loop),
     });
     builder
 }
@@ -31,6 +31,10 @@ pub fn run<E: UserEvent>(engine: Engine<E>) {
         .extract();
 
     main_loop.run((event_loop, context));
+}
+
+pub(crate) fn main_loop<E: UserEvent>(engine: Engine<E>) {
+
 }
 
 #[cfg(test)]

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -82,7 +82,7 @@ mod framework_runner_test {
 
     #[test]
     fn should_add_custom_main_loop() {
-        let (event_loop, context) = crate::init::<()>()
+        let (event_loop, mut context) = crate::init::<()>()
             .with_main_loop(|engine| {})
             .build()
             .unwrap();

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -10,7 +10,7 @@ pub use framework_builder::*;
 
 pub mod plugins;
 
-use wolf_engine_core::events::UserEvent;
+use wolf_engine_core::{events::UserEvent, Engine};
 
 /// Initializes Wolf Engine using the [`FrameworkBuilder`].
 pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -26,7 +26,8 @@ pub fn run<E: UserEvent>(engine: Engine<E>) {
 
     let mut main_loop = context.resources_mut()
         .remove::<MainLoopResource<E>>()
-        .expect("No main loop.  Make sure you used `framework::init()` to set up the Engine")
+        .expect(
+            "No main loop.  Make sure you used `wolf_engine::framework::init()` to set up the Engine")
         .extract();
 
     main_loop.run((event_loop, context));

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -22,7 +22,7 @@ pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
 }
 
 pub fn run<E: UserEvent>(engine: Engine<E>) {
-    let (event_loop, mut context) = engine;  
+    let (event_loop, mut context) = engine;
 
     let mut main_loop = context.resources_mut()
         .remove::<MainLoopResource<E>>()
@@ -33,9 +33,7 @@ pub fn run<E: UserEvent>(engine: Engine<E>) {
     main_loop.run((event_loop, context));
 }
 
-pub(crate) fn main_loop<E: UserEvent>(engine: Engine<E>) {
-
-}
+pub(crate) fn main_loop<E: UserEvent>(engine: Engine<E>) {}
 
 #[cfg(test)]
 mod framework_init_tests {
@@ -70,7 +68,7 @@ impl<E: UserEvent> MainLoopResource<E> {
     }
 
     pub fn extract(self) -> Box<dyn MainLoop<E>> {
-        self.inner 
+        self.inner
     }
 }
 
@@ -79,7 +77,10 @@ pub trait MainLoop<E: UserEvent> {
     fn run(&mut self, engine: Engine<E>);
 }
 
-impl<E: UserEvent, T> MainLoop<E> for T where T: FnMut(Engine<E>) {
+impl<E: UserEvent, T> MainLoop<E> for T
+where
+    T: FnMut(Engine<E>),
+{
     fn run(&mut self, engine: Engine<E>) {
         (self)(engine)
     }
@@ -91,9 +92,7 @@ mod framework_runner_test {
 
     #[test]
     fn should_add_main_loop_resource() {
-        let (_event_loop, context) = crate::init::<()>()
-            .build()
-            .unwrap();
+        let (_event_loop, context) = crate::init::<()>().build().unwrap();
 
         assert!(
             context.resources().get::<MainLoopResource<()>>().is_some(),
@@ -104,9 +103,7 @@ mod framework_runner_test {
     #[test]
     fn should_add_custom_main_loop() {
         let mut mock_main_loop = MockMainLoop::new();
-        mock_main_loop.expect_run()
-            .once()
-            .return_const(());
+        mock_main_loop.expect_run().once().return_const(());
 
         let engine = crate::init::<()>()
             .with_main_loop(mock_main_loop)
@@ -119,8 +116,7 @@ mod framework_runner_test {
     #[test]
     #[should_panic]
     fn should_panic_without_main_loop() {
-        let engine = wolf_engine_core::init::<()>()
-            .build();
+        let engine = wolf_engine_core::init::<()>().build();
 
         crate::run(engine);
     }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -15,7 +15,9 @@ use wolf_engine_core::{events::UserEvent, Engine};
 /// Initializes Wolf Engine using the [`FrameworkBuilder`].
 pub fn init<E: UserEvent>() -> FrameworkBuilder<E> {
     let mut builder = FrameworkBuilder::<E>::new();
-    builder.with_resource(MainLoopResource{});
+    builder.with_resource(MainLoopResource::<E> {
+        inner: Box::from(|_engine| {}),
+    });
     builder
 }
 
@@ -42,11 +44,11 @@ mod framework_init_tests {
     }
 }
 
-pub(crate) struct MainLoopResource {
-     
+pub(crate) struct MainLoopResource<E: UserEvent> {
+    inner: Box<dyn MainLoop<E>>,
 }
 
-impl<E: UserEvent> MainLoop<E> for MainLoopResource {
+impl<E: UserEvent> MainLoop<E> for MainLoopResource<E> {
     fn run(self, engine: Engine<E>) {
         todo!()
     }
@@ -73,7 +75,7 @@ mod framework_runner_test {
             .unwrap();
 
         assert!(
-            context.resources().get::<MainLoopResource>().is_some(),
+            context.resources().get::<MainLoopResource<()>>().is_some(),
             "Main loop resource was not inserted"
         );
     }
@@ -86,7 +88,7 @@ mod framework_runner_test {
             .unwrap();
 
         let main_loop = context.resources_mut()
-            .remove::<MainLoopResource>()
+            .remove::<MainLoopResource<()>>()
             .expect("No MainLoopResource");
 
         main_loop.run((event_loop, context));

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -49,7 +49,7 @@ mod framework_runner_test {
             .unwrap();
 
         assert!(
-            context.resources().get::<MainLoop>().is_some(),
+            context.resources().get::<MainLoopResource>().is_some(),
             "Main loop resource was not inserted"
         );
     }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -46,6 +46,12 @@ pub(crate) struct MainLoopResource {
      
 }
 
+impl<E: UserEvent> MainLoop<E> for MainLoopResource {
+    fn run(self, engine: Engine<E>) {
+        todo!()
+    }
+}
+
 pub trait MainLoop<E: UserEvent> {
     fn run(self, engine: Engine<E>);
 }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -72,9 +72,15 @@ mod framework_runner_test {
 
     #[test]
     fn should_add_custom_main_loop() {
-        let (_event_loop, context) = crate::init::<()>()
+        let (event_loop, context) = crate::init::<()>()
             .with_main_loop(|engine| {})
             .build()
             .unwrap();
+
+        let main_loop = context.resources_mut()
+            .remove::<MainLoopResource>()
+            .expect("No MainLoopResource");
+
+        main_loop.run((event_loop, context));
     }
 }

--- a/wolf_engine_framework/src/lib.rs
+++ b/wolf_engine_framework/src/lib.rs
@@ -46,6 +46,10 @@ pub(crate) struct MainLoopResource {
      
 }
 
+pub trait MainLoop {
+    
+}
+
 #[cfg(test)]
 mod framework_runner_test {
     use super::*;

--- a/wolf_engine_framework/src/main_loop.rs
+++ b/wolf_engine_framework/src/main_loop.rs
@@ -18,7 +18,7 @@ impl<E: UserEvent> MainLoopResource<E> {
     pub fn set_main_loop(&mut self, main_loop: Box<dyn MainLoop<E>>) {
         self.inner = main_loop;
     }
-    
+
     /// Consumes the resource, and returns a pointer to underlying [`MainLoop`].
     pub fn extract(self) -> Box<dyn MainLoop<E>> {
         self.inner
@@ -40,4 +40,3 @@ where
         (self)(engine)
     }
 }
-

--- a/wolf_engine_framework/src/main_loop.rs
+++ b/wolf_engine_framework/src/main_loop.rs
@@ -1,0 +1,43 @@
+use wolf_engine_core::prelude::*;
+
+/// Provides a wrapper around some [`MainLoop`] implementation, making it possible to access it as
+/// a [`Resource`] at run-time.
+pub(crate) struct MainLoopResource<E: UserEvent> {
+    inner: Box<dyn MainLoop<E>>,
+}
+
+impl<E: UserEvent> MainLoopResource<E> {
+    /// Creates a new resource from the provided [`MainLoop`].
+    pub fn new<L: MainLoop<E> + 'static>(main_loop: L) -> Self {
+        Self {
+            inner: Box::from(main_loop),
+        }
+    }
+
+    /// Sets the inner [`MainLoop`].
+    pub fn set_main_loop(&mut self, main_loop: Box<dyn MainLoop<E>>) {
+        self.inner = main_loop;
+    }
+    
+    /// Consumes the resource, and returns a pointer to underlying [`MainLoop`].
+    pub fn extract(self) -> Box<dyn MainLoop<E>> {
+        self.inner
+    }
+}
+
+/// An implementation of the engine's main-loop.
+#[cfg_attr(test, mockall::automock)]
+pub trait MainLoop<E: UserEvent> {
+    /// Runs the main-loop until the engine quits.
+    fn run(&mut self, engine: Engine<E>);
+}
+
+impl<E: UserEvent, T> MainLoop<E> for T
+where
+    T: FnMut(Engine<E>),
+{
+    fn run(&mut self, engine: Engine<E>) {
+        (self)(engine)
+    }
+}
+


### PR DESCRIPTION
This PR introduces the "Main-Loop" system, and the `MainLoop` trait.

The `MainLoop` trait allows the engine's default loop to be changed, in order to provide different features, or extend how the engine works.  The main example is when integrating with Winit, where its `EventLoop` wants to take over the main-thread in order to run the whole program in a cross-platform-friendly way.  There is no clean way to integrate Winit into the default main loop, without rewriting it.

The `MainLoop` system allows plugins to overwrite the default loop with a custom one when needed.

# Changes Made

All notable changes introduced by this PR should be documented here.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

- Added `MainLoop` trait.
- Added `framework::run()` function.
- Added `EngineBuilder::with_main_loop()` method.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR
can be accepted.

- [x] New behaviors are covered by tests, and / or examples.
- [x] The documentation has been updated (if applicable.)
- [x] The version number has been bumped (if applicable.)
- [x] The feature branch is up to date with `main`. 
