### PR TITLE
Refactor: Remove `delegate` from Dependencies

### DIFF
--- a/wolf_engine_framework/Cargo.toml
+++ b/wolf_engine_framework/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["game-development", "game-engines"]
 [dependencies]
 wolf_engine_core = {path = "../wolf_engine_core", version = "0.26.0"}
 log = "0.4"
-delegate = "0.11.0"
 
 [dev-dependencies]
 test-case = "1.2"

--- a/wolf_engine_framework/src/scenes/scene.rs
+++ b/wolf_engine_framework/src/scenes/scene.rs
@@ -89,26 +89,31 @@ impl<E: UserEvent> Scene<E, Unloaded> {
 }
 
 impl<E: UserEvent> Scene<E, Loaded> {
-    delegate! {
-        to self.inner {
-            /// Updates the game state when the scene is active.
-            ///
-            /// Active updates can optionally return a [`SceneChange`](crate::scenes::SceneChange), to the
-            /// [`Stage`](crate::scenes::Stage) to change scenes.
-            pub fn update(&mut self, context: &mut Context<E>) -> Option<SceneChange<E>>;
+    /// Updates the game state when the scene is active.
+    ///
+    /// Active updates can optionally return a [`SceneChange`](crate::scenes::SceneChange), to the
+    /// [`Stage`](crate::scenes::Stage) to change scenes.
+    pub fn update(&mut self, context: &mut Context<E>) -> Option<SceneChange<E>> {
+        self.inner.update(context)
+    }
+    /// Renders the current game state when the scene is active.
+    pub fn render(&mut self, context: &mut Context<E>) {
+        self.inner.render(context)
+    }
 
-            /// Renders the current game state when the scene is active.
-            pub fn render(&mut self, context: &mut Context<E>);
+    /// Updates the current state when the scene is in the background.
+    pub fn background_update(&mut self, context: &mut Context<E>) {
+        self.inner.background_update(context)
+    }
 
-            /// Updates the current state when the scene is in the background.
-            pub fn background_update(&mut self, context: &mut Context<E>);
+    /// Renders the current state when the scene is in the background.
+    pub fn background_render(&mut self, context: &mut Context<E>) {
+        self.inner.background_render(context)
+    }
 
-            /// Renders the current state when the scene is in the background.
-            pub fn background_render(&mut self, context: &mut Context<E>);
-
-            /// Unloads the scene, consuming, and dropping it in the process.
-            pub fn unload(mut self, context: &mut Context<E>);
-        }
+    /// Unloads the scene, consuming, and dropping it in the process.
+    pub fn unload(mut self, context: &mut Context<E>) {
+        self.inner.unload(context)
     }
 }
 

--- a/wolf_engine_framework/src/scenes/scene.rs
+++ b/wolf_engine_framework/src/scenes/scene.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use delegate::delegate;
 use wolf_engine_core::events::UserEvent;
 use wolf_engine_core::Context;
 


### PR DESCRIPTION
This PR removes the `delegate` crate from the dependencies, and replaces the auto-generated impls with manually written ones.  I'm replacing it because it only saves a few lines, and contributes to dependency bloat fairly significantly.

# Changes Made

All notable changes introduced by this PR should be documented here.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

- Removed `delegate` crate from `framework` dependencies.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR
can be accepted.

- [x] New behaviors are covered by tests, and / or examples.
- [x] The documentation has been updated (if applicable.)
- [x] The version number has been bumped (if applicable.)
- [x] The feature branch is up to date with `main`. 
