### PR TITLE
Changed Main `wolf_engine` Crate to Contain Only Re-Exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,24 +15,17 @@
 //! - `serde`: Enables [Serde](https://crates.io.crates/serde) support for some types.
 //! - `window`: Enables Wolf Engine's high-level window API.
 
-pub use wolf_engine_core::prelude::*;
+pub use wolf_engine_core as core;
 
 #[cfg(feature = "framework")]
-pub mod framework {
-    //! Provides a high-level, "batteries-included" framework.
-    pub use wolf_engine_framework::*;
-}
+pub use wolf_engine_framework as framework;
 
 #[cfg(feature = "logging")]
-pub use wolf_engine_core::logging;
+pub use wolf_engine_core::logging as logging;
 
 #[cfg(feature = "window")]
-pub mod window {
-    //! Provides a high-level, back-end agnostic window API.
-    pub use wolf_engine_window::*;
-}
+pub use wolf_engine_window as window;
 
-#[doc(hidden)]
 pub mod prelude {
-    pub use super::*;
+    pub use wolf_engine_core::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use wolf_engine_core as core;
 pub use wolf_engine_framework as framework;
 
 #[cfg(feature = "logging")]
-pub use wolf_engine_core::logging as logging;
+pub use wolf_engine_core::logging;
 
 #[cfg(feature = "window")]
 pub use wolf_engine_window as window;


### PR DESCRIPTION
I want WE to be more of a collection of independent (wherever possible) crates. Rather than having the `wolf_engine` crate contain the `core` api, now it just re-exports all other crates.  I have also provided a `prelude` to keep the usage more-or-less the same as before. 

# Changes Made

All notable changes introduced by this PR should be documented here.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

- Changed public use of `wolf_engine_core::prelude::*` to `wolf_engine_core` as `core`.
- Changed `framework` module to `wolf_engine_framework` as `framework`.
- Changed `window` module to `wolf_engine_window` as `window`.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR
can be accepted.

- [x] New behaviors are covered by tests, and / or examples.
- [x] The documentation has been updated (if applicable.)
- [x] The version number has been bumped (if applicable.)
- [x] The feature branch is up to date with `main`. 
