### PR TITLE
Bug Fix: Infinite Loop on Quit

### DIFF
--- a/engine/wolf_engine_core/src/events/event_loop.rs
+++ b/engine/wolf_engine_core/src/events/event_loop.rs
@@ -58,28 +58,22 @@ impl EventLoop {
             self.has_quit = true;
         }
     }
-
-    fn handle_empty_event(&self) -> Option<EventBox> {
-        if self.has_quit {
-            None
-        } else {
-            Some(Box::from(EngineEvent::EventsCleared))
-        }
-    }
 }
 
 impl EventReceiver<EventBox> for EventLoop {
     fn next_event(&mut self) -> Option<EventBox> {
-        match self.event_receiver.next_event() {
-            Some(event) => {
-                if let Some(downcast) = event.downcast_ref::<EngineEvent>() {
-                    self.handle_event(downcast);
-                    Some(event)
-                } else {
+        if self.has_quit {
+            None
+        } else {
+            match self.event_receiver.next_event() {
+                Some(event) => {
+                    if let Some(downcast) = event.downcast_ref::<EngineEvent>() {
+                        self.handle_event(downcast);
+                    }
                     Some(event)
                 }
+                None => Some(Box::from(EngineEvent::EventsCleared)),
             }
-            None => self.handle_empty_event(),
         }
     }
 }

--- a/engine/wolf_engine_core/src/events/event_loop.rs
+++ b/engine/wolf_engine_core/src/events/event_loop.rs
@@ -142,7 +142,7 @@ mod event_loop_tests {
             if let Some(engine_event) = event.downcast_ref::<EngineEvent>() {
                 match engine_event {
                     EngineEvent::Quit => context.quit(),
-                    _ => (),
+                    EngineEvent::EventsCleared => context.quit(),
                 }
             }
         }

--- a/engine/wolf_engine_core/src/events/event_loop.rs
+++ b/engine/wolf_engine_core/src/events/event_loop.rs
@@ -133,4 +133,18 @@ mod event_loop_tests {
             "The event-loop did not emit the expected EventsCleared event."
         );
     }
+
+    #[test]
+    #[timeout(100)]
+    fn should_not_infinite_loop_when_quit_is_emitted_while_handing_a_quit_event() {
+        let (mut event_loop, context) = crate::init().build().unwrap();
+        while let Some(event) = event_loop.next_event() {
+            if let Some(engine_event) = event.downcast_ref::<EngineEvent>() {
+                match engine_event {
+                    EngineEvent::Quit => context.quit(),
+                    _ => (),
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
If a `Quit` event is emitted while another `Quit` event is being handled, the`EventLoop` will get stuck in an infinite loop of emitting `Quit` events.  Now the `has_quit` flag is checked *before* emitting any events, and if it is`true`, then `None` is always returned.

# Changes Made

All notable changes introduced by this PR should be documented here.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

- Fixed infinite loop on quit.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR
can be accepted.

- [x] New behaviors are covered by tests, and / or examples.
- [x] The documentation has been updated (if applicable.)
- [x] The version number has been bumped (if applicable.)
- [x] The feature branch is up to date with `main`. 
