### PR TITLE
Refactor: Moved the Code from `generic_event_queue` into `wolf_engine_events`

### DIFF
--- a/crates/wolf_engine_events/src/event_queue.rs
+++ b/crates/wolf_engine_events/src/event_queue.rs
@@ -1,0 +1,33 @@
+/// The event-receiving half of an Event-Queue.
+pub trait EventReceiver<E> {
+    /// Returns the next event in the queue.
+    fn next_event(&mut self) -> Option<E>;
+}
+
+/// The event-sending half of an Event-Queue.
+///
+/// Event Senders can be freely, and safely cloned, given away, and even sent across threads.
+pub trait EventSender<E>: Send + Sync {
+    /// Sends an event to the receiver.  
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the receiver has been dropped.
+    fn send_event(&self, event: E) -> Result<(), ReceiverDroppedError>;
+}
+
+/// An error indicating the [`EventReceiver`] associated with an [`EventSender`] has been dropped,
+/// and there is nowhere to send events.
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub struct ReceiverDroppedError;
+
+impl std::error::Error for ReceiverDroppedError {}
+
+impl std::fmt::Display for ReceiverDroppedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Failed to send the event, because the receiver was dropped."
+        )
+    }
+}

--- a/crates/wolf_engine_events/src/lib.rs
+++ b/crates/wolf_engine_events/src/lib.rs
@@ -1,13 +1,10 @@
 //! Provides an event system for Wolf Engine.
 //!
-//! This module provides a [FIFO](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics))
-//! (First-in, First-out) event system based on the sender / receiver / message channel model
-//! found in [std::sync::mpsc].
-//!
 //! # Examples
 //!
-//! All event queues use the same API, so the following examples should work for any type
-//! implementing the Event-Queue traits.  
+//! This module provides a [FIFO](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics))
+//! (First-in, First-out) event system based on the sender / receiver / message channel found in 
+//! [std::sync::mpsc].
 //!
 //! ## Create an Event Queue
 //!

--- a/crates/wolf_engine_events/src/lib.rs
+++ b/crates/wolf_engine_events/src/lib.rs
@@ -1,6 +1,114 @@
 //! Provides an event system for Wolf Engine.
+//!
+//! This module provides a [FIFO](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics))
+//! (First-in, First-out) event system based on the sender / receiver / message channel model
+//! found in [std::sync::mpsc].
+//!
+//! # Examples
+//!
+//! All event queues use the same API, so the following examples should work for any type
+//! implementing the Event-Queue traits.  
+//!
+//! ## Create an Event Queue
+//!
+//! ```
+//! # use generic_event_queue::*;
+//! # enum EventType { Event };
+//! #
+//! let (event_sender, event_receiver) = mpsc::event_queue();
+//! #
+//! # event_sender.send_event(123);
+//! ```
+//!
+//! ## Handling Events
+//!
+//! An [`EventReceiver`] will collect incoming events, and store them until they are ready to be
+//! processed.  The order of incoming events is always preserved.
+//!
+//! Queued events are queried in a loop.  Querying events requires you have mutable access to the
+//! Event Queue.
+//!
+//! ```
+//! # use generic_event_queue::*;
+//! # enum EventType { Event };
+//! #
+//! # let (event_sender, mut event_receiver) = mpsc::event_queue::<EventType>();
+//! #
+//! while let Some(event) = event_receiver.next_event() {
+//!     match event {
+//!         EventType::Event => (), // Handle the event.
+//!     }
+//! }
+//! ```
+//!
+//! ## Sending Events
+//!
+//! To send an event to an [`EventReceiver`], we use an [`EventSender`].  An event sender is like
+//! a tunnel, through which you can send data, and it will pop out on the other side.  
+//!
+//! ```
+//! # use generic_event_queue::*;
+//! # enum EventType { Event };
+//! # let (event_sender, event_receiver) = mpsc::event_queue();
+//! #
+//! event_sender.send_event(EventType::Event);
+//! ```
+//!
+//! ### Cloning, and Transferring Ownership of an `EventSender`
+//!
+//! Event Senders are extremely useful because they can be freely, and safely cloned, and their
+//! ownership moved to other code that needs to send events.  This enables sending events from
+//! code that otherwise does not have access to the Event Queue.
+//!
+//! ```
+//! # use generic_event_queue::*;
+//! # #[derive(Clone)]
+//! # enum EventType { Event };
+//! #
+//! # struct SomeOtherType {
+//! #     pub event_sender: mpsc::MpscEventSender<EventType>,
+//! # }
+//! #
+//! # impl SomeOtherType {
+//! #   fn new(event_sender: mpsc::MpscEventSender<EventType>) -> Self {
+//! #       Self { event_sender }
+//! #   }
+//! # }
+//! #
+//! # fn some_other_function(event_sender: &mpsc::MpscEventSender<EventType>) {}
+//! #
+//! # let (event_sender, event_receiver) = mpsc::event_queue();
+//! #
+//! // The EventSender can be cloned, and freely passed around.
+//! let other_type = SomeOtherType::new(event_sender.clone());
+//! some_other_function(&event_sender);
+//!
+//! // The original EventSender is unaffected.
+//! event_sender.send_event(EventType::Event);
+//! ```
+//!
+//! ### Sending an `EventSender` to Another Thread
+//!
+//! Event Senders can be safely sent to other threads.
+//!
+//! ```
+//! # use generic_event_queue::*;
+//! # enum EventType { Event };
+//! # let (event_sender, event_receiver) = mpsc::event_queue();
+//! #
+//! // This EventSender stays on the main thread with the EventReceiver.
+//! event_sender.send_event(EventType::Event);
+//!
+//! // The clone is moved to the other thread.
+//! let thread_sender = event_sender.clone();
+//! std::thread::spawn(move || {
+//!     thread_sender.send_event(EventType::Event);
+//! }).join();
+//! ```
 
-pub use generic_event_queue::*;
+mod event_queue;
 
 pub mod dynamic;
 pub mod events;
+pub use event_queue::*;
+pub mod mpsc;

--- a/crates/wolf_engine_events/src/lib.rs
+++ b/crates/wolf_engine_events/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Examples
 //!
 //! This module provides a [FIFO](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics))
-//! (First-in, First-out) event system based on the sender / receiver / message channel found in 
+//! (First-in, First-out) event system based on the sender / receiver / message channel found in
 //! [std::sync::mpsc].
 //!
 //! ## Create an Event Queue

--- a/crates/wolf_engine_events/src/mpsc.rs
+++ b/crates/wolf_engine_events/src/mpsc.rs
@@ -1,0 +1,92 @@
+//! Provides a Multi-Producer, Single-Consumer Event-Queue implementation.
+
+use std::sync::mpsc::*;
+
+use crate::*;
+
+/// Creates a new mpsc sender / receiver pair.
+pub fn event_queue<E>() -> (MpscEventSender<E>, MpscEventReceiver<E>) {
+    let (sender, receiver) = channel();
+    let sender = MpscEventSender { inner: sender };
+    let receiver = MpscEventReceiver { inner: receiver };
+    (sender, receiver)
+}
+
+/// Provides the [`EventReceiver`] half of the event queue created by [`event_queue()`].
+pub struct MpscEventReceiver<E> {
+    inner: Receiver<E>,
+}
+
+impl<E: 'static> EventReceiver<E> for MpscEventReceiver<E> {
+    fn next_event(&mut self) -> Option<E> {
+        self.inner.try_recv().ok()
+    }
+}
+
+/// Provides the [`EventSender`] half of the event queue created by [`event_queue()`].
+pub struct MpscEventSender<E> {
+    inner: Sender<E>,
+}
+
+impl<E> Clone for MpscEventSender<E> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+// **SAFETY:** This type is backed by `std::sync::mpsc::Sender`, which is `Send` / `Sync`, so, by
+// extensions, this type is also safe to be `Send` / `Sync`.
+unsafe impl<E> Send for MpscEventSender<E> {}
+unsafe impl<E> Sync for MpscEventSender<E> {}
+
+impl<E> EventSender<E> for MpscEventSender<E> {
+    fn send_event(&self, event: E) -> Result<(), ReceiverDroppedError> {
+        match self.inner.send(event) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(ReceiverDroppedError),
+        }
+    }
+}
+
+#[cfg(test)]
+mod event_queue_tests {
+    use std::thread;
+
+    pub use super::*;
+
+    #[test]
+    pub fn should_send_and_receive_events() {
+        let (event_sender, mut event_queue) = event_queue();
+
+        event_sender.send_event(0).unwrap();
+
+        assert_eq!(event_queue.next_event().expect("No event in the queue"), 0);
+    }
+
+    #[test]
+    pub fn should_send_events_and_receive_events_across_threads() {
+        let (event_sender, mut event_queue) = event_queue();
+
+        event_sender.send_event(0).unwrap();
+        let thread_sender = event_sender.clone();
+        thread::spawn(move || {
+            thread_sender.send_event(1).unwrap();
+        })
+        .join()
+        .unwrap();
+        event_sender.send_event(2).unwrap();
+
+        assert_eq!(event_queue.next_event().expect("No event in the queue."), 0);
+        assert_eq!(event_queue.next_event().expect("No event in the queue."), 1);
+        assert_eq!(event_queue.next_event().expect("No event in the queue."), 2);
+    }
+
+    #[test]
+    pub fn should_flush_empty_list_if_there_are_no_events() {
+        let (_event_sender, mut event_queue) = event_queue::<i32>();
+
+        assert!(event_queue.next_event().is_none());
+    }
+}


### PR DESCRIPTION
I had originally moved the event queue code into it's own crate so it could be shared with my other projects.  It doesn't really make sense to do this anymore, since the `wolf_engine_events` crate is designed as a stand-alone module.  The new events module kinda makes `generic_event_queue` redundant.  Having it here also makes maintaining this code, specifically for Wolf Engine, a lot easier.

I'm probably going to retire `generic_event_queue` completely, and just use the events package instead.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Bumped crate version numbers.
- [x] Updated the Changelog.
- [x] Merged changes from the `main` branch.
