### PR TITLE
Feature: Mouse Scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Added `state` field.
     - Added `scancode` field.
     - Added `keycode` field.
-  - Added `MouseMoved` variant.
+  - Added `MouseMove` variant.
     - Added `x` field.
     - Added `y` field.
-  - Added `RawMouseMoved` variant.
+  - Added `RawMouseMove` variant.
     - Added `delta_x` field.
     - Added `delta_y` field.
   - Added `MouseButton` variant.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `MouseButton` variant.
     - Added `state` field.
     - Added `button` field.
+  - Added `MouseScroll` variant.
+    - Added `delta_x` field.
+    - Added `delta_y` field.
 - Added `ToInput` trait.
   - Added `to_input()` method.
 - Added `keyboard` module.

--- a/crates/wolf_engine_input/src/lib.rs
+++ b/crates/wolf_engine_input/src/lib.rs
@@ -45,7 +45,7 @@ pub enum Input {
     /// The mouse has moved.
     ///
     /// This event indicates the mouse has moved to a specific point in the window.
-    MouseMoved { x: f32, y: f32 },
+    MouseMove { x: f32, y: f32 },
 
     /// The mouse has moved.
     ///
@@ -55,7 +55,7 @@ pub enum Input {
     /// This event is not associated with a window.  It may be emitted alongside a normal
     /// [`MouseMoved`](Input::MouseMoved) events.  Some window systems may filter out raw events
     /// when the window is not in-focus.
-    RawMouseMoved { delta_x: f32, delta_y: f32 },
+    RawMouseMove { delta_x: f32, delta_y: f32 },
 
     /// A mouse button was pressed / released.
     MouseButton {

--- a/crates/wolf_engine_input/src/lib.rs
+++ b/crates/wolf_engine_input/src/lib.rs
@@ -45,7 +45,10 @@ pub enum Input {
     /// The mouse has moved.
     ///
     /// This event indicates the mouse has moved to a specific point in the window.
-    MouseMoved { x: f32, y: f32 },
+    MouseMoved {
+        x: f32,
+        y: f32,
+    },
 
     /// The mouse has moved.
     ///
@@ -55,10 +58,17 @@ pub enum Input {
     /// This event is not associated with a window.  It may be emitted alongside a normal
     /// [`MouseMoved`](Input::MouseMoved) events.  Some window systems may filter out raw events
     /// when the window is not in-focus.
-    RawMouseMoved { delta_x: f32, delta_y: f32 },
+    RawMouseMoved {
+        delta_x: f32,
+        delta_y: f32,
+    },
     MouseButton {
         state: ButtonState,
         button: MouseButton,
+    },
+    MouseScroll {
+        delta_x: f32,
+        delta_y: f32,
     },
 }
 

--- a/crates/wolf_engine_input/src/lib.rs
+++ b/crates/wolf_engine_input/src/lib.rs
@@ -45,10 +45,7 @@ pub enum Input {
     /// The mouse has moved.
     ///
     /// This event indicates the mouse has moved to a specific point in the window.
-    MouseMoved {
-        x: f32,
-        y: f32,
-    },
+    MouseMoved { x: f32, y: f32 },
 
     /// The mouse has moved.
     ///
@@ -58,18 +55,16 @@ pub enum Input {
     /// This event is not associated with a window.  It may be emitted alongside a normal
     /// [`MouseMoved`](Input::MouseMoved) events.  Some window systems may filter out raw events
     /// when the window is not in-focus.
-    RawMouseMoved {
-        delta_x: f32,
-        delta_y: f32,
-    },
+    RawMouseMoved { delta_x: f32, delta_y: f32 },
+
+    /// A mouse button was pressed / released.
     MouseButton {
         state: ButtonState,
         button: MouseButton,
     },
-    MouseScroll {
-        delta_x: f32,
-        delta_y: f32,
-    },
+
+    /// The mouse was scrolled.
+    MouseScroll { delta_x: f32, delta_y: f32 },
 }
 
 /// Indicates the current state of a button input.

--- a/crates/wolf_engine_input/src/winit.rs
+++ b/crates/wolf_engine_input/src/winit.rs
@@ -2,7 +2,7 @@ use crate::keyboard::KeyCode;
 use crate::mouse::MouseButton;
 use crate::{ButtonState, Input, ToInput};
 
-use winit::event::{KeyEvent, WindowEvent};
+use winit::event::{KeyEvent, MouseScrollDelta, WindowEvent};
 use winit::{
     event::{DeviceEvent, ElementState, Event, MouseButton as WinitMouseButton, RawKeyEvent},
     keyboard::{KeyCode as WinitKeyCode, PhysicalKey},
@@ -30,6 +30,13 @@ impl ToInput for WindowEvent {
             WindowEvent::MouseInput { state, button, .. } => Some(Input::MouseButton {
                 state: (*state).into(),
                 button: (*button).into(),
+            }),
+            WindowEvent::MouseWheel {
+                delta: MouseScrollDelta::LineDelta(x, y),
+                ..
+            } => Some(Input::MouseScroll {
+                delta_x: *x,
+                delta_y: *y,
             }),
             _ => None,
         }

--- a/crates/wolf_engine_input/src/winit.rs
+++ b/crates/wolf_engine_input/src/winit.rs
@@ -23,7 +23,7 @@ impl ToInput for WindowEvent {
     fn to_input(&self) -> Option<Input> {
         match self {
             WindowEvent::KeyboardInput { event, .. } => Some(event.clone().into()),
-            WindowEvent::CursorMoved { position, .. } => Some(Input::MouseMoved {
+            WindowEvent::CursorMoved { position, .. } => Some(Input::MouseMove {
                 x: position.x.trunc() as f32,
                 y: position.y.trunc() as f32,
             }),
@@ -65,7 +65,7 @@ impl ToInput for DeviceEvent {
     fn to_input(&self) -> Option<Input> {
         match self {
             DeviceEvent::Key(event) => Some(event.clone().into()),
-            DeviceEvent::MouseMotion { delta } => Some(Input::RawMouseMoved {
+            DeviceEvent::MouseMotion { delta } => Some(Input::RawMouseMove {
                 delta_x: delta.0 as f32,
                 delta_y: delta.1 as f32,
             }),

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -55,5 +55,6 @@ fn process_input(input: &Input) {
             println!("Raw Mouse Moved: {delta_x}, {delta_y}")
         }
         Input::MouseButton { state, button } => println!("Mouse Button: {button:?} {state:?}"),
+        Input::MouseScroll { delta_x, delta_y } => println!("Mouse Scrolled: {delta_x} {delta_y}"),
     }
 }

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -50,8 +50,8 @@ fn process_input(input: &Input) {
             scancode,
             keycode,
         } => println!("Raw Key: {state:?}, {scancode:?}, {keycode:?}"),
-        Input::MouseMoved { x, y } => println!("Mouse Moved: {x}, {y}"),
-        Input::RawMouseMoved { delta_x, delta_y } => {
+        Input::MouseMove { x, y } => println!("Mouse Moved: {x}, {y}"),
+        Input::RawMouseMove { delta_x, delta_y } => {
             println!("Raw Mouse Moved: {delta_x}, {delta_y}")
         }
         Input::MouseButton { state, button } => println!("Mouse Button: {button:?} {state:?}"),


### PR DESCRIPTION
Looks like I forgot to add support for mouse scrolling in #10, so I've added it in this PR.  I've also renamed the `MouseMoved`, and `RawMouseMoved` events to `MouseMove`, and `RawMouseMove`.  Mostly to stay consistent with the naming style of the other events.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
