### PR TITLE
Documentation: Add description to input crate

### DIFF
--- a/crates/wolf_engine_input/Cargo.toml
+++ b/crates/wolf_engine_input/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "wolf_engine_input"
+description = "A high-level input API."
 version = "0.1.0"
 authors = ["AlexiWolf <alexi@wolvesin.space>"]
 edition = "2021"

--- a/crates/wolf_engine_input/src/lib.rs
+++ b/crates/wolf_engine_input/src/lib.rs
@@ -53,7 +53,7 @@ pub enum Input {
     /// FPS-like camera controls.
     ///
     /// This event is not associated with a window.  It may be emitted alongside a normal
-    /// [`MouseMoved`](Input::MouseMoved) events.  Some window systems may filter out raw events
+    /// [`MouseMove`](Input::MouseMove) events.  Some window systems may filter out raw events
     /// when the window is not in-focus.
     RawMouseMove { delta_x: f32, delta_y: f32 },
 


### PR DESCRIPTION
Added missing `description` field to the input crate.  Because I forgot to do it earlier apparently.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
