### PR TITLE
Dependencies: Remove Specific Patch Number from Winit Dependency in the Input Crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [wolf_engine_input]
 
+### [0.1.1] - 2024-24-03
+
+- Changed winit dependency version to any `0.29` release.
+
 ### [0.1] - 2024-24-03
 
 - Added `ButtonState` enum.

--- a/crates/wolf_engine_input/Cargo.toml
+++ b/crates/wolf_engine_input/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["wolf-engine", "gamedev", "input"]
 categories = ["game-development", "game-engines"]
 
 [dependencies]
-winit = { version = "0.29.14", optional = true }
+winit = { version = "0.29", optional = true }
 
 [dev-dependencies]
 test-case = "3.3.1"


### PR DESCRIPTION
It's probably best not to pin winit to a specific patch number.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
