### PR TITLE
Make the Events Module a Required Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `winit` feature to enable / disable Winit integration engine-wide.
 - Added `wolf_engine_events` crate.
   - Added public re-export of `wolf_engine_events` as `events`.
-  - Added `events` feature to enable / disable the `events` module.
-    - Added `events` feature to the default feature-set.
 
 ## [wolf_engine_input]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ members = ["crates/*"]
 
 [dependencies]
 wolf_engine_events = { version = "0.1.0", path = "crates/wolf_engine_events", optional = true }
+wolf_engine_events = { version = "0.1.0", path = "crates/wolf_engine_events" }
 wolf_engine_input = { version = "0.1.1", path = "crates/wolf_engine_input", optional = true }
 
 [features]
-default = ["events", "input"]
-events = ["wolf_engine_events"]
+default = ["input"]
 input = ["wolf_engine_input"]
 winit = ["wolf_engine_input/winit"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["game-development", "game-engines"]
 members = ["crates/*"]
 
 [dependencies]
-wolf_engine_events = { version = "0.1.0", path = "crates/wolf_engine_events", optional = true }
 wolf_engine_events = { version = "0.1.0", path = "crates/wolf_engine_events" }
 wolf_engine_input = { version = "0.1.1", path = "crates/wolf_engine_input", optional = true }
 


### PR DESCRIPTION
I changed the `wolf_engine_events` dependency from optional to required.  Basically everything in the engine uses the event traits.  There's no good reason to make them optional.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
