### PR TITLE
Bugfix: Unneeded Feature `cfg` Permanently Disables the `events` Module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "events")]
 pub use wolf_engine_events as events;
 
 #[cfg(feature = "input")]


### PR DESCRIPTION
Looks like I forgot to remove the feature `cfg` for the `events` module in #17. Since the `events` feature has been removed, this permanently disables the `events` module.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
