### PR TITLE
Update/winit 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [0.1.1] - 2024-03-24
 
-- Changed winit dependency version to any `0.29` release.
+- Updated `winit` integration to `v0.29.x`. 
 
 ### [0.1] - 2024-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [wolf_engine_input]
 
+### [0.1.2] - 2023-07-09
+
+- Updated `winit` integration to `v0.30.x`.
+
 ### [0.1.1] - 2024-24-03
 
 - Changed winit dependency version to any `0.29` release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated `winit` integration to `v0.30.x`.
 
-### [0.1.1] - 2024-24-03
+### [0.1.1] - 2024-03-24
 
 - Changed winit dependency version to any `0.29` release.
 
-### [0.1] - 2024-24-03
+### [0.1] - 2024-03-24
 
 - Added `ButtonState` enum.
   - Added `Down` variant.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ winit = ["wolf_engine_input/winit"]
 window = ["wolf_engine_window"]
 
 [dev-dependencies]
-winit = "0.29.14"
+winit = "0.30"
 pixels = "0.13.0"
 
 [[example]]

--- a/crates/wolf_engine_input/Cargo.toml
+++ b/crates/wolf_engine_input/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["wolf-engine", "gamedev", "input"]
 categories = ["game-development", "game-engines"]
 
 [dependencies]
-winit = { version = "0.29", optional = true }
+winit = { version = "0.30", optional = true }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -2,11 +2,12 @@ use winit::{
     dpi::PhysicalSize,
     event::{Event, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::WindowAttributes,
 };
 use wolf_engine::input::ToInput;
 use wolf_engine_input::Input;
 
+#[allow(deprecated)]
 pub fn main() {
     let event_loop = EventLoop::new().unwrap();
     let mut window = None;
@@ -17,11 +18,13 @@ pub fn main() {
         match event {
             Event::Resumed => {
                 window = Some(
-                    WindowBuilder::new()
-                        .with_title("Wolf Engine - Input Example")
-                        .with_inner_size(PhysicalSize::new(800, 600))
-                        .with_resizable(false)
-                        .build(&window_target)
+                    window_target
+                        .create_window(
+                            WindowAttributes::default()
+                                .with_title("Wolf Engine - Input Example")
+                                .with_inner_size(PhysicalSize::new(800, 600))
+                                .with_resizable(false),
+                        )
                         .unwrap(),
                 );
             }


### PR DESCRIPTION
Updated the `winit` integrations in `wolf_engine_input` from `v0.29.x` to `v0.30.x`.  The `input` example needed a few changes, but beyond that, all the tests are passing.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
