### PR TITLE
Add public re-export of `winit` in `wolf_engine_input`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `HasRawWindowHandles` trait.
   - Added `HasRwh5Handles` trait.
   - Added `HasRwh6Handles` trait.
+- Added public re-export of the `winit` crate.
 
 ## [wolf_engine_input]
 

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -5,6 +5,8 @@ use winit::{
     window::{Window as WinitWindow, WindowAttributes},
 };
 
+pub use winit;
+
 /// Re-exports supported [`raw_window_handle`](crate::raw_window_handle::rwh_06) versions.
 pub mod raw_window_handle;
 


### PR DESCRIPTION
Added a public re-export of `winit`.  Because I'm planning to use Winit's types in the API, I'm adding this re-export so there's an easy way to get the correct version of Winit.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
