### PR TITLE
Feature: Add Error to Window Context Build

### DIFF
--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -1,5 +1,6 @@
 use winit::{
     dpi::PhysicalSize,
+    error::EventLoopError,
     event::{Event as WinitEvent, WindowEvent as WinitWindowEvent},
     event_loop::{ControlFlow, EventLoop, EventLoopProxy},
     window::{Window as WinitWindow, WindowAttributes},
@@ -66,11 +67,11 @@ impl WindowContextBuilder {
     }
 
     /// Initialize the window system.
-    pub fn build(self) -> WindowContext {
-        let event_loop = EventLoop::with_user_event()
-            .build()
-            .expect("Failed to initialize the window system");
-        self.build_with_event_loop(event_loop)
+    pub fn build(self) -> Result<WindowContext, EventLoopError> {
+        match EventLoop::with_user_event().build() {
+            Ok(event_loop) => Ok(self.build_with_event_loop(event_loop)),
+            Err(error) => Err(error),
+        }
     }
 
     #[allow(deprecated)]

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -7,7 +7,8 @@ fn main() {
         .with_title("Wolf Engine - Window Example")
         .with_size((800, 600))
         .with_resizable(true)
-        .build();
+        .build()
+        .unwrap();
 
     window.run(|event, window| match event {
         WindowEvent::Resumed => {


### PR DESCRIPTION
Changed the return type of `WindowContextBuilder::build()` to a `Result`.  This way, failures can be handled if desired.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
