### PR TITLE
Feature: Type-States to Guard Against Invalid Window Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [0.1] - 2024-07-09
+
 - Added `init()` fn.
 - Added `WindowContext` struct.
 - Added `WindowContextBuilder` struct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+- Added type-states to `WindowContext`.
+  - Added `context_state` mod.
+    - Added `Inactive` struct.
+    - Added `Active` struct.
+  - Added generic `state` parameter to `WindowContext`.
+  - Moved the following methods to `Inactive` state.
+    - `run()`.
+  - Moved the following methods to the `Active` state.
+    - `size()`.
+    - `close()`.
+  - Moved all `raw_window_handle` trait impls to the `Active` state.
+
 ### [0.1] - 2024-07-09
 
 - Added `init()` fn.

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -129,7 +129,7 @@ impl WindowContextBuilder {
 
 pub mod context_state {
     pub struct Inactive;
-    pub struct Running;
+    pub struct Active;
 }
 
 /// Provides a simple window-system.
@@ -157,7 +157,7 @@ impl WindowContext {
 }
 
 impl WindowContext<context_state::Inactive> {
-    fn create_running_context(self) -> WindowContext<context_state::Running> {
+    fn create_running_context(self) -> WindowContext<context_state::Active> {
         WindowContext {
             event_loop: self.event_loop,
             event_loop_proxy: self.event_loop_proxy,
@@ -169,7 +169,7 @@ impl WindowContext<context_state::Inactive> {
 
     /// Run the event-loop, passing events to the provided `event_handler`.
     #[allow(deprecated)]
-    pub fn run<F: FnMut(WindowEvent, &WindowContext<context_state::Running>)>(
+    pub fn run<F: FnMut(WindowEvent, &WindowContext<context_state::Active>)>(
         mut self,
         mut event_handler: F,
     ) {
@@ -227,7 +227,7 @@ impl WindowContext<context_state::Inactive> {
     }
 }
 
-impl WindowContext<context_state::Running> {
+impl WindowContext<context_state::Active> {
     /// Get the current size of the window.
     ///
     /// # Panics
@@ -278,27 +278,27 @@ enum BackendEvent {
     CloseRequested,
 }
 
-impl rwh_06::HasWindowHandle for WindowContext<context_state::Running> {
+impl rwh_06::HasWindowHandle for WindowContext<context_state::Active> {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         rwh_06::HasWindowHandle::window_handle(self.window())
     }
 }
 
-impl rwh_06::HasDisplayHandle for WindowContext<context_state::Running> {
+impl rwh_06::HasDisplayHandle for WindowContext<context_state::Active> {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         rwh_06::HasDisplayHandle::display_handle(self.window())
     }
 }
 
 #[cfg(feature = "rwh_05")]
-unsafe impl rwh_05::HasRawWindowHandle for WindowContext<context_state::Running> {
+unsafe impl rwh_05::HasRawWindowHandle for WindowContext<context_state::Active> {
     fn raw_window_handle(&self) -> rwh_05::RawWindowHandle {
         rwh_05::HasRawWindowHandle::raw_window_handle(self.window())
     }
 }
 
 #[cfg(feature = "rwh_05")]
-unsafe impl rwh_05::HasRawDisplayHandle for WindowContext<context_state::Running> {
+unsafe impl rwh_05::HasRawDisplayHandle for WindowContext<context_state::Active> {
     fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
         rwh_05::HasRawDisplayHandle::raw_display_handle(self.window())
     }

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -127,6 +127,11 @@ impl WindowContextBuilder {
     }
 }
 
+pub mod context_state {
+    pub struct Inactive;
+    pub struct Running;
+}
+
 /// Provides a simple window-system.
 ///
 /// Create, and configure the Window Context with [`init()`].

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -156,8 +156,6 @@ impl WindowContext {
     }
 }
 
-    fn maybe_window(&self) -> &WinitWindow {
-        self.window.as_ref().expect("Window not created yet")
 impl WindowContext<context_state::Inactive> {
     }
 
@@ -240,6 +238,10 @@ impl WindowContext<context_state::Running> {
             .send_event(BackendEvent::CloseRequested)
             .unwrap();
     }
+
+    fn window(&self) -> &WinitWindow {
+        self.window.as_ref().expect("Window not created yet")
+    }
 }
 
 /// The settings used by the [`WindowContext`] when creating the window.
@@ -269,27 +271,27 @@ enum BackendEvent {
 
 impl rwh_06::HasWindowHandle for WindowContext<context_state::Running> {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
-        rwh_06::HasWindowHandle::window_handle(self.maybe_window())
+        rwh_06::HasWindowHandle::window_handle(self.window())
     }
 }
 
 impl rwh_06::HasDisplayHandle for WindowContext<context_state::Running> {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
-        rwh_06::HasDisplayHandle::display_handle(self.maybe_window())
+        rwh_06::HasDisplayHandle::display_handle(self.window())
     }
 }
 
 #[cfg(feature = "rwh_05")]
 unsafe impl rwh_05::HasRawWindowHandle for WindowContext<context_state::Running> {
     fn raw_window_handle(&self) -> rwh_05::RawWindowHandle {
-        rwh_05::HasRawWindowHandle::raw_window_handle(self.maybe_window())
+        rwh_05::HasRawWindowHandle::raw_window_handle(self.window())
     }
 }
 
 #[cfg(feature = "rwh_05")]
 unsafe impl rwh_05::HasRawDisplayHandle for WindowContext<context_state::Running> {
     fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::HasRawDisplayHandle::raw_display_handle(self.maybe_window())
+        rwh_05::HasRawDisplayHandle::raw_display_handle(self.window())
     }
 }
 

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -41,6 +41,8 @@
 //! integrates with the [`raw_window_handle`] crate in order to interoperate with external
 //! rendering libraries.
 
+use std::marker::PhantomData;
+
 use winit::{
     dpi::PhysicalSize,
     error::EventLoopError,

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -127,8 +127,13 @@ impl WindowContextBuilder {
     }
 }
 
+/// Type-states used by the [`WindowContext`].
 pub mod context_state {
+
+    /// Indicates the context has not run yet.
     pub struct Inactive;
+
+    /// Indicates the context has run, and the window has been created.
     pub struct Active;
 }
 

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -128,11 +128,12 @@ impl WindowContextBuilder {
 /// Provides a simple window-system.
 ///
 /// Create, and configure the Window Context with [`init()`].
-pub struct WindowContext {
+pub struct WindowContext<State = context_state::Inactive> {
     event_loop: Option<WinitEventLoop>,
     event_loop_proxy: EventLoopProxy<BackendEvent>,
     window: Option<WinitWindow>,
     window_settings: WindowSettings,
+    _state: PhantomData<State>,
 }
 
 impl WindowContext {
@@ -143,6 +144,7 @@ impl WindowContext {
             event_loop_proxy,
             window: None,
             window_settings,
+            _state: PhantomData,
         }
     }
 }


### PR DESCRIPTION
Added type-states to the `WindowContext`, so there's a clear distinction between a context that's "Inactive" (the window system isn't running, and window hasn't been created yet), or "Active" (the window system is running, and the window has been created.)  This way, we use compiler to both guard against invalid usage, and more clearly communicate to the user which methods they are able to use.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
