### PR TITLE
Feature: Add `Window` Struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added generic `state` parameter to `WindowContext`.
   - Moved the following methods to `Inactive` state.
     - `run()`.
-  - Moved the following methods to the `Active` state.
+- Added `Window` struct.
+  - Added `WindowContext::window()` accessor to `Active` state.
+  - Moved window-related methods from `WindowContext` to the `Window` struct.
     - `size()`.
     - `close()`.
-  - Moved all `raw_window_handle` trait impls to the `Active` state.
+    - All `raw_window_handle` trait impls.
+
 
 ### [0.1] - 2024-07-09
 

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -277,20 +277,19 @@ enum BackendEvent {
 }
 
 pub struct Window {
-    inner: Weak<WinitWindow>,
+    inner: Arc<WinitWindow>,
 }
 
 impl Window {
     fn new(inner: &Arc<WinitWindow>) -> Self {
         Self {
-            inner: Arc::downgrade(inner),
+            inner: Arc::clone(inner),
         }
     }
 
     /// Get the current size of the window.
     pub fn size(&self) -> (u32, u32) {
-        let window = self.inner.upgrade().unwrap();
-        let size = window.inner_size();
+        let size = self.inner.inner_size();
         (size.width, size.height)
     }
 }

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -287,29 +287,29 @@ pub struct Window {}
 
 impl Window {}
 
-impl rwh_06::HasWindowHandle for WindowContext<context_state::Active> {
+impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
-        rwh_06::HasWindowHandle::window_handle(self.window())
+        todo!()
     }
 }
 
-impl rwh_06::HasDisplayHandle for WindowContext<context_state::Active> {
+impl rwh_06::HasDisplayHandle for Window {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
-        rwh_06::HasDisplayHandle::display_handle(self.window())
+        todo!()
     }
 }
 
 #[cfg(feature = "rwh_05")]
-unsafe impl rwh_05::HasRawWindowHandle for WindowContext<context_state::Active> {
+unsafe impl rwh_05::HasRawWindowHandle for Window {
     fn raw_window_handle(&self) -> rwh_05::RawWindowHandle {
-        rwh_05::HasRawWindowHandle::raw_window_handle(self.window())
+        rwh_05::HasRawWindowHandle::raw_window_handle(&self.inner.upgrade().unwrap())
     }
 }
 
 #[cfg(feature = "rwh_05")]
-unsafe impl rwh_05::HasRawDisplayHandle for WindowContext<context_state::Active> {
+unsafe impl rwh_05::HasRawDisplayHandle for Window {
     fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::HasRawDisplayHandle::raw_display_handle(self.window())
+        rwh_05::HasRawDisplayHandle::raw_display_handle(&self.inner.upgrade().unwrap())
     }
 }
 

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -41,7 +41,10 @@
 //! integrates with the [`raw_window_handle`] crate in order to interoperate with external
 //! rendering libraries.
 
-use std::marker::PhantomData;
+use std::{
+    marker::PhantomData,
+    sync::{Arc, Weak},
+};
 
 use winit::{
     dpi::PhysicalSize,
@@ -143,7 +146,7 @@ pub mod context_state {
 pub struct WindowContext<State = context_state::Inactive> {
     event_loop: Option<WinitEventLoop>,
     event_loop_proxy: EventLoopProxy<BackendEvent>,
-    window: Option<WinitWindow>,
+    window: Option<Arc<WinitWindow>>,
     window_settings: WindowSettings,
     _state: PhantomData<State>,
 }
@@ -192,7 +195,7 @@ impl WindowContext<context_state::Inactive> {
                     }
                 }
                 WinitEvent::Resumed => {
-                    context.window = Some(
+                    context.window = Some(Arc::new(
                         event_loop
                             .create_window(
                                 WindowAttributes::default()
@@ -205,7 +208,7 @@ impl WindowContext<context_state::Inactive> {
                                     .with_visible(context.window_settings.is_visible),
                             )
                             .expect("Window creation failed"),
-                    );
+                    ));
                     (event_handler)(WindowEvent::Resumed, &context);
                 }
                 WinitEvent::WindowEvent {

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -253,7 +253,7 @@ impl WindowContext<context_state::Active> {
             .unwrap();
     }
 
-    fn window(&self) -> &WinitWindow {
+    pub fn window(&self) -> &WinitWindow {
         self.window.as_ref().expect("Window not created yet")
     }
 }

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -283,6 +283,10 @@ enum BackendEvent {
     CloseRequested,
 }
 
+pub struct Window {}
+
+impl Window {}
+
 impl rwh_06::HasWindowHandle for WindowContext<context_state::Active> {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         rwh_06::HasWindowHandle::window_handle(self.window())

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -273,6 +273,7 @@ enum BackendEvent {
     CloseRequested,
 }
 
+#[derive(Clone, Debug)]
 pub struct Window {
     inner: Arc<WinitWindow>,
 }

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -236,17 +236,6 @@ impl WindowContext<context_state::Inactive> {
 }
 
 impl WindowContext<context_state::Active> {
-    /// Get the current size of the window.
-    ///
-    /// # Panics
-    ///
-    /// - Will panic if the window has not been created yet.  This happens on
-    /// [`WindowEvent::Resumed`].
-    pub fn size(&self) -> (u32, u32) {
-        let size = self.window().inner_size();
-        (size.width, size.height)
-    }
-
     /// Close the current window.
     ///
     /// The window system will stop after this.
@@ -298,6 +287,12 @@ impl Window {
         }
     }
 
+    /// Get the current size of the window.
+    pub fn size(&self) -> (u32, u32) {
+        let window = self.inner.upgrade().unwrap();
+        let size = window.inner_size();
+        (size.width, size.height)
+    }
 }
 
 impl rwh_06::HasWindowHandle for Window {

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -236,7 +236,7 @@ impl WindowContext<context_state::Active> {
     /// Access the [`Window`].
     pub fn window(&self) -> Window {
         let window = self.window.as_ref().expect("Window not created yet");
-        Window::new(&window, self.event_loop_proxy.clone())
+        Window::new(window.clone(), self.event_loop_proxy.clone())
     }
 }
 
@@ -276,9 +276,9 @@ pub struct Window {
 }
 
 impl Window {
-    fn new(inner: &Arc<WinitWindow>, event_loop_proxy: EventLoopProxy<BackendEvent>) -> Self {
+    fn new(inner: Arc<WinitWindow>, event_loop_proxy: EventLoopProxy<BackendEvent>) -> Self {
         Self {
-            inner: Arc::clone(inner),
+            inner,
             event_loop_proxy,
         }
     }

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -236,7 +236,7 @@ impl WindowContext<context_state::Active> {
     /// Access the [`Window`].
     pub fn window(&self) -> Window {
         let window = self.window.as_ref().expect("Window not created yet");
-        Window::new(&window)
+        Window::new(&window, self.event_loop_proxy.clone())
     }
 }
 
@@ -272,12 +272,14 @@ enum BackendEvent {
 #[derive(Clone, Debug)]
 pub struct Window {
     inner: Arc<WinitWindow>,
+    event_loop_proxy: EventLoopProxy<BackendEvent>,
 }
 
 impl Window {
-    fn new(inner: &Arc<WinitWindow>) -> Self {
+    fn new(inner: &Arc<WinitWindow>, event_loop_proxy: EventLoopProxy<BackendEvent>) -> Self {
         Self {
             inner: Arc::clone(inner),
+            event_loop_proxy,
         }
     }
 

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -296,27 +296,27 @@ impl Window {
 
 impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
-        todo!()
+        rwh_06::HasWindowHandle::window_handle(&self.inner)
     }
 }
 
 impl rwh_06::HasDisplayHandle for Window {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
-        todo!()
+        rwh_06::HasDisplayHandle::display_handle(&self.inner)
     }
 }
 
 #[cfg(feature = "rwh_05")]
 unsafe impl rwh_05::HasRawWindowHandle for Window {
     fn raw_window_handle(&self) -> rwh_05::RawWindowHandle {
-        rwh_05::HasRawWindowHandle::raw_window_handle(&self.inner.upgrade().unwrap())
+        rwh_05::HasRawWindowHandle::raw_window_handle(&self.inner)
     }
 }
 
 #[cfg(feature = "rwh_05")]
 unsafe impl rwh_05::HasRawDisplayHandle for Window {
     fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::HasRawDisplayHandle::raw_display_handle(&self.inner.upgrade().unwrap())
+        rwh_05::HasRawDisplayHandle::raw_display_handle(&self.inner)
     }
 }
 

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -41,10 +41,7 @@
 //! integrates with the [`raw_window_handle`] crate in order to interoperate with external
 //! rendering libraries.
 
-use std::{
-    marker::PhantomData,
-    sync::{Arc, Weak},
-};
+use std::{marker::PhantomData, sync::Arc};
 
 use winit::{
     dpi::PhysicalSize,

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -273,6 +273,10 @@ enum BackendEvent {
     CloseRequested,
 }
 
+/// A window.
+///
+/// Windows are created by the [`WindowContext`], and can be accessed by calling
+/// [`WindowContext::window()`].
 #[derive(Clone, Debug)]
 pub struct Window {
     inner: Arc<WinitWindow>,

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -233,15 +233,6 @@ impl WindowContext<context_state::Inactive> {
 }
 
 impl WindowContext<context_state::Active> {
-    /// Close the current window.
-    ///
-    /// The window system will stop after this.
-    pub fn close(&self) {
-        self.event_loop_proxy
-            .send_event(BackendEvent::CloseRequested)
-            .unwrap();
-    }
-
     /// Access the [`Window`].
     pub fn window(&self) -> Window {
         let window = self.window.as_ref().expect("Window not created yet");
@@ -294,6 +285,15 @@ impl Window {
     pub fn size(&self) -> (u32, u32) {
         let size = self.inner.inner_size();
         (size.width, size.height)
+    }
+
+    /// Close the current window.
+    ///
+    /// The window system will stop after this.
+    pub fn close(&self) {
+        self.event_loop_proxy
+            .send_event(BackendEvent::CloseRequested)
+            .unwrap();
     }
 }
 
@@ -365,7 +365,7 @@ mod window_init_tests {
         let mut has_quit = false;
 
         context.run(|event, window| match event {
-            WindowEvent::Resumed => window.close(),
+            WindowEvent::Resumed => window.window().close(),
             WindowEvent::Closed => *&mut has_quit = true,
             _ => (),
         });

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -256,8 +256,9 @@ impl WindowContext<context_state::Active> {
             .unwrap();
     }
 
-    pub fn window(&self) -> &WinitWindow {
-        self.window.as_ref().expect("Window not created yet")
+    pub fn window(&self) -> Window {
+        let window = self.window.as_ref().expect("Window not created yet");
+        Window::new(&window)
     }
 }
 

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -242,6 +242,7 @@ impl WindowContext<context_state::Active> {
             .unwrap();
     }
 
+    /// Access the [`Window`].
     pub fn window(&self) -> Window {
         let window = self.window.as_ref().expect("Window not created yet");
         Window::new(&window)

--- a/crates/wolf_engine_window/src/lib.rs
+++ b/crates/wolf_engine_window/src/lib.rs
@@ -286,9 +286,18 @@ enum BackendEvent {
     CloseRequested,
 }
 
-pub struct Window {}
+pub struct Window {
+    inner: Weak<WinitWindow>,
+}
 
-impl Window {}
+impl Window {
+    fn new(inner: &Arc<WinitWindow>) -> Self {
+        Self {
+            inner: Arc::downgrade(inner),
+        }
+    }
+
+}
 
 impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -3,14 +3,14 @@ use wolf_engine::window::WindowEvent;
 
 fn main() {
     let mut pixels = None;
-    let window = wolf_engine::window::init()
+    let context = wolf_engine::window::init()
         .with_title("Wolf Engine - Window Example")
         .with_size((800, 600))
         .with_resizable(true)
         .build()
         .unwrap();
 
-    window.run(|event, window| match event {
+    context.run(|event, context| match event {
         WindowEvent::Resumed => {
             println!("Hello, world!");
             pixels = Some({

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -16,7 +16,7 @@ fn main() {
             pixels = Some({
                 let window = context.window();
                 let (width, height) = window.size();
-                let surface_texture = SurfaceTexture::new(width, height, window);
+                let surface_texture = SurfaceTexture::new(width, height, &window);
                 let mut pixels = Pixels::new(width, height, surface_texture).unwrap();
                 pixels.clear_color(Color::RED);
                 pixels

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -14,8 +14,9 @@ fn main() {
         WindowEvent::Resumed => {
             println!("Hello, world!");
             pixels = Some({
+                let window = context.window();
                 let (width, height) = window.size();
-                let surface_texture = SurfaceTexture::new(width, height, &window);
+                let surface_texture = SurfaceTexture::new(width, height, window);
                 let mut pixels = Pixels::new(width, height, surface_texture).unwrap();
                 pixels.clear_color(Color::RED);
                 pixels


### PR DESCRIPTION
Added a new `Window` struct, which wraps around the `WinitWindow`, allowing more direct access, and long-term references to the window, ext.  All window-related methods which used to be on `WindowContext` have been moved to the `Window` struct.  The window can now be accessed using `WindowContext::window()`.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
