### PR TITLE
Refactor: Remove `RawKeyboard` Inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [wolf_engine_input]
 
+### [Unreleased]
+
+- Changed "raw" keyboard input to use the normal `Keyboard` input.
+  - Removed `Input::RawKeyboard` variant.
+
 ### [0.1.2] - 2023-07-09
 
 - Updated `winit` integration to `v0.30.x`.

--- a/crates/wolf_engine_input/src/lib.rs
+++ b/crates/wolf_engine_input/src/lib.rs
@@ -31,17 +31,6 @@ pub enum Input {
         is_repeat: bool,
     },
 
-    /// A keyboard button was pressed / released.
-    ///
-    /// This event is is not associated with a window.  It may be emitted alongside a normal
-    /// [`Keyboard`](Input::Keyboard) event.  Some window systems may filter out raw events when
-    /// the window is not in-focus.
-    RawKeyboard {
-        state: ButtonState,
-        scancode: u32,
-        keycode: Option<KeyCode>,
-    },
-
     /// The mouse has moved.
     ///
     /// This event indicates the mouse has moved to a specific point in the window.

--- a/crates/wolf_engine_input/src/lib.rs
+++ b/crates/wolf_engine_input/src/lib.rs
@@ -40,10 +40,6 @@ pub enum Input {
     ///
     /// This event indicates the mouse has moved, and by how much.  It's most useful to games with
     /// FPS-like camera controls.
-    ///
-    /// This event is not associated with a window.  It may be emitted alongside a normal
-    /// [`MouseMove`](Input::MouseMove) events.  Some window systems may filter out raw events
-    /// when the window is not in-focus.
     RawMouseMove { delta_x: f32, delta_y: f32 },
 
     /// A mouse button was pressed / released.

--- a/crates/wolf_engine_input/src/winit.rs
+++ b/crates/wolf_engine_input/src/winit.rs
@@ -82,10 +82,11 @@ impl From<RawKeyEvent> for Input {
             KeyCode::Unknown => None,
             keycode => Some(keycode),
         };
-        Input::RawKeyboard {
+        Input::Keyboard {
             state,
             scancode,
             keycode,
+            is_repeat: false,
         }
     }
 }

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -48,11 +48,6 @@ fn process_input(input: &Input) {
             keycode,
             is_repeat,
         } => println!("Key: {state:?}, {scancode:?}, {keycode:?}, {is_repeat:?}"),
-        Input::RawKeyboard {
-            state,
-            scancode,
-            keycode,
-        } => println!("Raw Key: {state:?}, {scancode:?}, {keycode:?}"),
         Input::MouseMove { x, y } => println!("Mouse Moved: {x}, {y}"),
         Input::RawMouseMove { delta_x, delta_y } => {
             println!("Raw Mouse Moved: {delta_x}, {delta_y}")


### PR DESCRIPTION
Removed the `Input::RawKeyboard` variant, because it's mostly-identical to the normal `Keyboard` input, minus the `raw_input`.  Raw-keyboard inputs can always set this value to false, and there is no need for a separate variant for them.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
