### PR TITLE
Docs: Add Missing Docs / Changelog Entries for the `events` Crate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,24 +159,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
-- Removed the `dynamic` feature.
-  - Removed the `dynamic` module.
-  - Removed `dynamic` feature to enable / disable the `dynamic` module.
-  - Removed `dynamic` module.
-    - Removed `event_loop` module.
-      - Removed `EventLoop` struct.
-        - Removed `EventReceiver` impl.
-        - Removed `Default` impl.
-        - Removed `event_sender()` method.
-    - Removed `events` module.
-      - Removed `Quit` event.
-      - Removed `EventsCleared` event.
-    - Removed `DynamicEvent` trait.
-    - Removed `DynamicEventSender` trait.
-      - Removed auto-impl for `EventSender<DynamicEventBox>` types.
-      - Removed a provided `send_event()` method.
-    - Removed `DynamicEventBox` type-def of `Box<dyn DynamicEvent>`.
-    - Removed `DynamicEvent` derive macro.
+- Add missing docs / changelog entry. 
+
+### [0.2] - 2024-11-03
+
+- Simplified the dynamic event system a bit.
+  - Removed the `dynamic` feature flag, since most things are likely going to
+    use the dynamic events system anyways.
+  - Renamed `DynaimcEventBox` to `AnyEvent`.
+  - Removed derive macro for `DynamicEvent`.
+  - Removed `DynamicEventSender`.
+  - Removed the `dynamic::events` module.
+  - Removed the `dynamic::event_loop` module.
+  - Changed the `EventLoop` struct into a trait.
+
 
 ### [0.1] - 2024-03-07
 

--- a/crates/wolf_engine_events/src/event_loop.rs
+++ b/crates/wolf_engine_events/src/event_loop.rs
@@ -1,6 +1,12 @@
+//! The [EventLoop] trait, and associated types.
+
 use crate::mpsc::MpscEventSender;
 
+/// An event-driven main-loop.
 pub trait EventLoop<E> {
+    /// Get an event-sender which can send events to the event-loop.
     fn event_sender(&self) -> MpscEventSender<E>;
+
+    /// Run the main-loop.
     fn run<F: FnMut(E)>(self, event_handler: F);
 }


### PR DESCRIPTION
Add missing documentation to the events crate, and updated its changelog entry, because I forgot to do it on the last update.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
