### PR TITLE
Feature: Add Input Support to the Window System

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `HasRwh6Handles` trait.
 - Added public re-export of the `winit` crate.
 
+
+## [wolf_engine_winit]
+
+## [Unreleased]
+
+- Added EventLoop / main-loop implementation based on `winit`.
+- Added basic window-system features:
+  - Added window creation / deletion.
+  - Added window resizing.
+  - Added multi-window support.
+  - Added Raw Window Handle integration.
+  - Added window inputs.
+
 ## [wolf_engine_input]
 
 ### [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [wolf_engine_window]
 
+### [Unreleased]
+
+- Remove compiler error when no `rwh` features are enabled.
+
 ### [0.4] 2024-11-03
 
 - Changed to event-driven window creation.

--- a/crates/wolf_engine_window/src/raw_window_handle.rs
+++ b/crates/wolf_engine_window/src/raw_window_handle.rs
@@ -8,9 +8,6 @@ pub use rwh_06;
 
 use uuid::Uuid;
 
-#[cfg(not(any(feature = "rwh_06", feature = "rwh_05")))]
-compile_error!("You must enable at least one rwh version: 'rwh_06', or 'rwh_05'");
-
 /// A type which has [rwh_06] handles.
 #[cfg(feature = "rwh_06")]
 pub trait HasRwh6Handles: rwh_06::HasWindowHandle + rwh_06::HasDisplayHandle {}

--- a/crates/wolf_engine_winit/src/lib.rs
+++ b/crates/wolf_engine_winit/src/lib.rs
@@ -12,6 +12,7 @@ use wolf_engine_events::{
     mpsc::{self, MpscEventReceiver, MpscEventSender},
     EventReceiver, EventSender,
 };
+use wolf_engine_input::ToInput;
 use wolf_engine_window::{
     backend::{
         event::{WindowContextEvent, WindowContextEventSender},
@@ -213,7 +214,24 @@ impl<H: FnMut(AnyEvent)> ApplicationHandler for WinitApp<H> {
             WinitEvent::RedrawRequested => {
                 (self.event_handler)(Box::new(WindowEvent::WindowRedrawRequested(uuid)))
             }
-            _ => (),
+            _ => match event.to_input() {
+                Some(input) => {
+                    (self.event_handler)(Box::new(WindowEvent::Input(Some(uuid), input)))
+                }
+                None => (),
+            },
+        }
+    }
+
+    fn device_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        _device_id: winit::event::DeviceId,
+        event: winit::event::DeviceEvent,
+    ) {
+        match event.to_input() {
+            Some(input) => (self.event_handler)(Box::new(WindowEvent::Input(None, input))),
+            None => (),
         }
     }
 }

--- a/crates/wolf_engine_winit/src/lib.rs
+++ b/crates/wolf_engine_winit/src/lib.rs
@@ -214,9 +214,11 @@ impl<H: FnMut(AnyEvent)> ApplicationHandler for WinitApp<H> {
             WinitEvent::RedrawRequested => {
                 (self.event_handler)(Box::new(WindowEvent::WindowRedrawRequested(uuid)))
             }
-            _ => if let Some(input) = event.to_input() {
-                (self.event_handler)(Box::new(WindowEvent::Input(Some(uuid), input)))
-            },
+            _ => {
+                if let Some(input) = event.to_input() {
+                    (self.event_handler)(Box::new(WindowEvent::Input(Some(uuid), input)))
+                }
+            }
         }
     }
 
@@ -226,6 +228,8 @@ impl<H: FnMut(AnyEvent)> ApplicationHandler for WinitApp<H> {
         _device_id: winit::event::DeviceId,
         event: winit::event::DeviceEvent,
     ) {
-        if let Some(input) = event.to_input() { (self.event_handler)(Box::new(WindowEvent::Input(None, input))) }
+        if let Some(input) = event.to_input() {
+            (self.event_handler)(Box::new(WindowEvent::Input(None, input)))
+        }
     }
 }

--- a/crates/wolf_engine_winit/src/lib.rs
+++ b/crates/wolf_engine_winit/src/lib.rs
@@ -214,11 +214,8 @@ impl<H: FnMut(AnyEvent)> ApplicationHandler for WinitApp<H> {
             WinitEvent::RedrawRequested => {
                 (self.event_handler)(Box::new(WindowEvent::WindowRedrawRequested(uuid)))
             }
-            _ => match event.to_input() {
-                Some(input) => {
-                    (self.event_handler)(Box::new(WindowEvent::Input(Some(uuid), input)))
-                }
-                None => (),
+            _ => if let Some(input) = event.to_input() {
+                (self.event_handler)(Box::new(WindowEvent::Input(Some(uuid), input)))
             },
         }
     }
@@ -229,9 +226,6 @@ impl<H: FnMut(AnyEvent)> ApplicationHandler for WinitApp<H> {
         _device_id: winit::event::DeviceId,
         event: winit::event::DeviceEvent,
     ) {
-        match event.to_input() {
-            Some(input) => (self.event_handler)(Box::new(WindowEvent::Input(None, input))),
-            None => (),
-        }
+        if let Some(input) = event.to_input() { (self.event_handler)(Box::new(WindowEvent::Input(None, input))) }
     }
 }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -43,7 +43,9 @@ fn main() {
                         pixels.resize_surface(*width, *height).unwrap();
                     }
                 }
-                WindowEvent::Input(_, input) => println!("Input into window: {:?}", input),
+                WindowEvent::Input(uuid, input) => {
+                    println!("Input into window ({:?}): {:?}", uuid, input)
+                }
                 WindowEvent::WindowClosed(_) => context.exit(),
                 WindowEvent::Exited => println!("Goodbye, World!"),
                 _ => (),


### PR DESCRIPTION
Hooked up inputs in the Winit backend, so now, input events will be converted, and emitted as WE Window events.

# Merge Checklist

- [x] Added tests or examples for new / changed behaviors.
- [x] Updated the docs.
- [x] Updated the Changelog.
